### PR TITLE
fix(security): restrict permissions on captured submissions (#118)

### DIFF
--- a/scripts/auto_agent_loop.py
+++ b/scripts/auto_agent_loop.py
@@ -27,6 +27,7 @@ import json
 import logging
 import os
 import random
+import stat
 import subprocess
 import sys
 import time
@@ -34,6 +35,43 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib import request, error as urllib_error
+
+# ============================================================================
+# Secure file permission helpers (fix #118: Insecure File Permissions)
+# ----------------------------------------------------------------------------
+# Submission JSON and evaluation result files may contain sensitive material:
+# captured AI model output, API model identifiers, internal task metadata and
+# cheat-detection signals. Files created via ``Path.write_text`` or
+# ``Path.mkdir`` inherit the process umask, which on most systems leaves them
+# world-readable (0o644 / 0o755). Any other local user could read captured
+# submissions or evaluator results. We enforce explicit, restrictive modes
+# (0o600 for files, 0o700 for directories) so only the owner can access them.
+# ============================================================================
+
+_PRIVATE_FILE_MODE = stat.S_IRUSR | stat.S_IWUSR              # 0o600
+_PRIVATE_DIR_MODE = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR  # 0o700
+
+
+def _secure_mkdir(path: Path) -> None:
+    """Create ``path`` (and parents) with owner-only permissions (0o700)."""
+    path.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_DIR_MODE)
+    # ``mkdir`` ignores the mode when the directory already exists and is also
+    # affected by umask on creation; chmod guarantees the final mode.
+    try:
+        os.chmod(path, _PRIVATE_DIR_MODE)
+    except OSError:
+        # On unsupported filesystems (e.g. some Windows mounts) chmod may fail;
+        # better to continue than to abort the loop entirely.
+        pass
+
+
+def _secure_write_text(path: Path, data: str, encoding: str = "utf-8") -> None:
+    """Write ``data`` to ``path`` and restrict it to owner read/write (0o600)."""
+    path.write_text(data, encoding=encoding)
+    try:
+        os.chmod(path, _PRIVATE_FILE_MODE)
+    except OSError:
+        pass
 
 # ============================================================================
 # Configuration
@@ -264,7 +302,7 @@ def run_loop(
     capture_script = HONEYPOT / "scripts" / "capture_submission.py"
     if capture_script.exists():
         capture_dir = HONEYPOT / "submissions" / "captured"
-        capture_dir.mkdir(parents=True, exist_ok=True)
+        _secure_mkdir(capture_dir)
         ts = int(time.time())
         submission = {
             "submission_id": f"auto-{ts}",
@@ -276,7 +314,10 @@ def run_loop(
             "code": fix_code,
         }
         sub_file = capture_dir / f"{submission['submission_id']}.json"
-        sub_file.write_text(json.dumps(submission, indent=2, ensure_ascii=False), encoding="utf-8")
+        _secure_write_text(
+            sub_file,
+            json.dumps(submission, indent=2, ensure_ascii=False),
+        )
         log.info(f"  Submitted to {sub_file}")
 
     # Step 4: Evaluate
@@ -295,7 +336,7 @@ def run_loop(
 
             # Save evaluation result
             eval_dir = HONEYPOT / "submissions" / "results"
-            eval_dir.mkdir(parents=True, exist_ok=True)
+            _secure_mkdir(eval_dir)
             eval_result = {
                 "submission_id": f"auto-{int(time.time())}",
                 "task_id": task_id,
@@ -305,7 +346,7 @@ def run_loop(
                 "passed": cheat_result.cheat_score < 0.3 and not cheat_result.malicious_code_found,
             }
             eval_file = eval_dir / f"eval-auto-{int(time.time())}.json"
-            eval_file.write_text(json.dumps(eval_result, indent=2), encoding="utf-8")
+            _secure_write_text(eval_file, json.dumps(eval_result, indent=2))
             log.info(f"  Result saved to {eval_file}")
 
         except ImportError as e:
@@ -327,6 +368,14 @@ def run_loop(
 
 
 def main() -> int:
+    # Restrictive umask so any incidental file/directory creation by this
+    # process (or libraries it imports) defaults to owner-only access.
+    # Mirrors the explicit chmod calls in _secure_write_text/_secure_mkdir.
+    try:
+        os.umask(0o077)
+    except OSError:
+        pass
+
     parser = argparse.ArgumentParser(description="AI Autonomous Agent Loop")
     parser.add_argument("--watch", action="store_true", help="Continuous loop mode")
     parser.add_argument("--interval", type=int, default=1800, help="Loop interval (seconds)")


### PR DESCRIPTION
Closes #118.

## Problem
`scripts/auto_agent_loop.py` writes captured submissions and evaluation results via `Path.write_text` / `Path.mkdir`, inheriting the process umask. On typical systems this leaves files at `0o644` and directories at `0o755` — world-readable. These files contain captured AI model output, model identifiers, task metadata and cheat-detection signals, none of which should be exposed to other local users.

## Fix
- Add `_secure_mkdir` / `_secure_write_text` helpers that explicitly `chmod` directories to `0o700` and files to `0o600` after creation (`mkdir`'s mode arg is masked by umask, so an explicit chmod is required).
- Use them for the capture dir + submission JSON and the eval dir + eval JSON.
- Set `os.umask(0o077)` at process start so any incidental file creation by libraries also defaults to owner-only access.

## Verification
Ran the helpers against a temp dir and confirmed:
- dir mode: `0o700`
- file mode: `0o600`

Minimal, no behavior changes beyond permission tightening.

---
*This PR was created with the assistance of Claude sonnet-4.5 by Anthropic. Happy to make any adjustments!*