### PR TITLE
fix: replace unsafe pickle deserialization — closes #325

### DIFF
--- a/fixes/pickle_rce_fix.py
+++ b/fixes/pickle_rce_fix.py
@@ -1,0 +1,443 @@
+"""
+Fix for Issue #325: Remote Code Execution via Unsafe Pickle Deserialization.
+
+Python's ``pickle`` module is a powerful serialization format, but it
+executes arbitrary Python code during deserialization.  Loading untrusted
+pickle data is therefore equivalent to remote code execution:
+
+    import pickle, os
+    class Exploit:
+        def __reduce__(self):
+            return (os.system, ('id',))
+    pickle.loads(pickle.dumps(Exploit()))   # executes: id
+
+This module provides safe alternatives that cover the common use-cases
+where pickle is misapplied to untrusted data:
+
+1. **JSON** (``safe_json_roundtrip``) — for plain Python primitives
+   (str, int, float, bool, None, list, dict).  Zero deserialization risk.
+
+2. **SafeUnpickler** — a strict allow-list unpickler for trusted formats
+   that *must* remain in pickle (e.g. legacy model checkpoints).
+   Only modules/classes explicitly listed in ``PICKLE_ALLOWLIST`` can be
+   instantiated.  Everything else raises ``PickleSecurityError``.
+
+3. **SafeModelLoader** — wraps common ML checkpoint helpers and routes
+   to JSON or an allow-listed unpickler so that ``torch.load()`` /
+   ``numpy.load()`` paths are never called on untrusted data without a
+   safety layer.
+
+4. **safe_yaml_load** — replaces the dangerous bare ``yaml.load()`` call
+   (which also allows arbitrary object construction) with
+   ``yaml.safe_load()``.
+
+Usage::
+
+    from fixes.pickle_rce_fix import (
+        safe_loads,
+        safe_json_roundtrip,
+        safe_yaml_load,
+        SafeModelLoader,
+    )
+
+    # Instead of: pickle.loads(user_data)
+    obj = safe_loads(user_data)            # raises on untrusted types
+
+    # Instead of: json.loads(data) with mixed pickle fall-back:
+    obj = safe_json_roundtrip(data)
+
+    # Instead of: yaml.load(stream)
+    cfg = safe_yaml_load(stream)           # uses yaml.safe_load internally
+
+    # For ML checkpoints:
+    loader = SafeModelLoader()
+    weights = loader.load_checkpoint(path)
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import pickle
+import pickletools
+import struct
+from pathlib import Path
+from typing import Any, FrozenSet, Mapping, Type, Union
+
+try:
+    import yaml as _yaml
+except ImportError:  # pragma: no cover
+    _yaml = None  # type: ignore[assignment]
+
+__all__ = [
+    "PickleSecurityError",
+    "PICKLE_ALLOWLIST",
+    "SafeUnpickler",
+    "safe_loads",
+    "safe_dumps",
+    "safe_json_roundtrip",
+    "safe_yaml_load",
+    "SafeModelLoader",
+]
+
+
+# ---------------------------------------------------------------------------
+# Exception
+# ---------------------------------------------------------------------------
+
+
+class PickleSecurityError(Exception):
+    """Raised when a pickle payload attempts to instantiate a disallowed type."""
+
+
+# ---------------------------------------------------------------------------
+# Allow-list: (module, qualname) pairs that are safe to deserialize
+# ---------------------------------------------------------------------------
+
+#: Extend this set in your application code when adding new safe types.
+PICKLE_ALLOWLIST: FrozenSet[tuple[str, str]] = frozenset(
+    {
+        # Pure Python builtins that carry no execution side-effects
+        ("builtins", "dict"),
+        ("builtins", "list"),
+        ("builtins", "tuple"),
+        ("builtins", "set"),
+        ("builtins", "frozenset"),
+        ("builtins", "str"),
+        ("builtins", "bytes"),
+        ("builtins", "bytearray"),
+        ("builtins", "int"),
+        ("builtins", "float"),
+        ("builtins", "complex"),
+        ("builtins", "bool"),
+        ("builtins", "type"),
+        # datetime (safe, no __reduce__ execution side-effects)
+        ("datetime", "datetime"),
+        ("datetime", "date"),
+        ("datetime", "time"),
+        ("datetime", "timedelta"),
+        ("datetime", "timezone"),
+        # collections
+        ("collections", "OrderedDict"),
+        ("collections", "defaultdict"),
+        ("collections", "namedtuple"),
+        # numpy arrays (safe data container only — no code in __reduce__)
+        ("numpy", "ndarray"),
+        ("numpy.core.multiarray", "_reconstruct"),
+        ("numpy", "dtype"),
+        ("numpy.core.multiarray", "scalar"),
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# SafeUnpickler
+# ---------------------------------------------------------------------------
+
+
+class SafeUnpickler(pickle.Unpickler):
+    """An Unpickler that refuses to instantiate any class not in the allow-list.
+
+    This is a defence-in-depth measure for legacy data that *must* remain
+    in pickle format.  For new data, prefer JSON.
+
+    Parameters
+    ----------
+    file:
+        A binary-mode file-like object (same as ``pickle.Unpickler``).
+    allowlist:
+        Set of ``(module, qualname)`` pairs that may be constructed.
+        Defaults to :data:`PICKLE_ALLOWLIST`.
+    max_bytes:
+        Reject payloads larger than this threshold to prevent DoS.
+        Defaults to 100 MB.
+    """
+
+    def __init__(
+        self,
+        file: io.RawIOBase,
+        *,
+        allowlist: FrozenSet[tuple[str, str]] = PICKLE_ALLOWLIST,
+        max_bytes: int = 100 * 1024 * 1024,
+    ) -> None:
+        super().__init__(file)
+        self._allowlist = allowlist
+        self._max_bytes = max_bytes
+
+    def find_class(self, module: str, name: str) -> Any:
+        """Block every class not in the allow-list."""
+        if (module, name) not in self._allowlist:
+            raise PickleSecurityError(
+                f"Deserialization of {module}.{name} is not permitted. "
+                "Only explicitly allow-listed types may be loaded from pickle."
+            )
+        return super().find_class(module, name)
+
+
+def _check_size(data: bytes, max_bytes: int) -> None:
+    if len(data) > max_bytes:
+        raise PickleSecurityError(
+            f"Pickle payload size {len(data):,} bytes exceeds the "
+            f"safety limit of {max_bytes:,} bytes."
+        )
+
+
+def safe_loads(
+    data: bytes,
+    *,
+    allowlist: FrozenSet[tuple[str, str]] = PICKLE_ALLOWLIST,
+    max_bytes: int = 100 * 1024 * 1024,
+) -> Any:
+    """Safely deserialize a pickle payload using the allow-list unpickler.
+
+    Raises :class:`PickleSecurityError` if the payload references any
+    module/class outside ``allowlist`` or exceeds ``max_bytes``.
+
+    This is the **drop-in replacement** for ``pickle.loads(untrusted_data)``.
+
+    >>> import pickle
+    >>> safe_loads(pickle.dumps({"key": [1, 2, 3]}))
+    {'key': [1, 2, 3]}
+    """
+    if not isinstance(data, (bytes, bytearray)):
+        raise TypeError(f"safe_loads expects bytes, got {type(data).__name__}")
+    _check_size(data, max_bytes)
+    return SafeUnpickler(io.BytesIO(data), allowlist=allowlist, max_bytes=max_bytes).load()
+
+
+def safe_dumps(obj: Any) -> bytes:
+    """Serialize *obj* to pickle bytes.
+
+    This is a thin wrapper around ``pickle.dumps`` provided for symmetry.
+    Serialization itself is always safe; only *deserialization* is dangerous.
+    """
+    return pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
+
+
+# ---------------------------------------------------------------------------
+# JSON helpers (preferred over pickle for untrusted data)
+# ---------------------------------------------------------------------------
+
+
+def safe_json_roundtrip(
+    data: Union[str, bytes],
+    *,
+    max_bytes: int = 10 * 1024 * 1024,
+) -> Any:
+    """Parse *data* as JSON and return the Python object.
+
+    Use this instead of ``pickle.loads`` whenever the payload is expected
+    to contain only plain data (dicts, lists, strings, numbers, booleans,
+    None).  JSON deserialization never executes arbitrary code.
+
+    Parameters
+    ----------
+    data:
+        UTF-8-encoded JSON string or bytes.
+    max_bytes:
+        Reject inputs larger than this to prevent DoS.
+
+    Raises
+    ------
+    ValueError
+        If *data* is not valid JSON.
+    PickleSecurityError
+        If *data* exceeds *max_bytes*.
+    """
+    raw = data.encode("utf-8") if isinstance(data, str) else data
+    if len(raw) > max_bytes:
+        raise PickleSecurityError(
+            f"JSON payload {len(raw):,} bytes exceeds safety limit of "
+            f"{max_bytes:,} bytes."
+        )
+    return json.loads(raw)
+
+
+def to_json_bytes(obj: Any, *, indent: int | None = None) -> bytes:
+    """Serialize *obj* to compact JSON bytes (UTF-8).
+
+    Raises ``TypeError`` for non-serialisable objects.
+    """
+    return json.dumps(obj, indent=indent, ensure_ascii=False).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# YAML helper (replaces yaml.load with yaml.safe_load)
+# ---------------------------------------------------------------------------
+
+
+def safe_yaml_load(stream: Union[str, bytes, io.IOBase]) -> Any:
+    """Parse YAML from *stream* using the safe loader.
+
+    ``yaml.load(stream)`` without an explicit ``Loader`` argument (or with
+    ``Loader=yaml.Loader`` / ``yaml.FullLoader``) allows arbitrary Python
+    object construction via the ``!!python/object`` tag family, equivalent
+    to pickle deserialization.
+
+    This function always uses ``yaml.safe_load``, which only allows standard
+    YAML types and raises ``yaml.constructor.ConstructorError`` on any
+    Python-specific tag.
+
+    Parameters
+    ----------
+    stream:
+        A YAML document as a string, bytes, or file-like object.
+
+    Raises
+    ------
+    RuntimeError
+        If the ``yaml`` package is not installed.
+    """
+    if _yaml is None:
+        raise RuntimeError(
+            "PyYAML is not installed. Install it with: pip install pyyaml"
+        )
+    # Always use safe_load — never yaml.load(stream, Loader=yaml.FullLoader)
+    return _yaml.safe_load(stream)
+
+
+# ---------------------------------------------------------------------------
+# ML model checkpoint loader
+# ---------------------------------------------------------------------------
+
+
+class SafeModelLoader:
+    """Safe wrapper for loading ML model checkpoints.
+
+    Prevents RCE that arises when ``torch.load()`` or ``pickle.load()``
+    is called on a user-supplied checkpoint without ``weights_only=True``
+    or an allow-list filter.
+
+    Usage::
+
+        loader = SafeModelLoader()
+        state_dict = loader.load_checkpoint("model.pt")
+    """
+
+    def __init__(
+        self,
+        *,
+        allowlist: FrozenSet[tuple[str, str]] = PICKLE_ALLOWLIST,
+        max_bytes: int = 2 * 1024 * 1024 * 1024,  # 2 GB
+    ) -> None:
+        self._allowlist = allowlist
+        self._max_bytes = max_bytes
+
+    def load_checkpoint(self, path: Union[str, Path]) -> Any:
+        """Load a model checkpoint from *path*.
+
+        Strategy:
+        1. If the file has a ``.json`` extension, parse as JSON.
+        2. If ``torch`` is available, use ``torch.load(..., weights_only=True)``
+           which is safe against RCE (PyTorch ≥ 2.0).
+        3. Otherwise fall back to :func:`safe_loads` with the allow-list
+           unpickler.
+
+        In all cases the file size is checked against *max_bytes* before
+        loading.
+
+        Raises
+        ------
+        PickleSecurityError
+            If any deserialization policy is violated.
+        FileNotFoundError
+            If *path* does not exist.
+        """
+        path = Path(path)
+        if not path.exists():
+            raise FileNotFoundError(f"Checkpoint not found: {path}")
+
+        size = path.stat().st_size
+        if size > self._max_bytes:
+            raise PickleSecurityError(
+                f"Checkpoint {path} ({size:,} bytes) exceeds the safety "
+                f"limit of {self._max_bytes:,} bytes."
+            )
+
+        # 1. JSON checkpoint
+        if path.suffix.lower() == ".json":
+            return json.loads(path.read_text(encoding="utf-8"))
+
+        # 2. PyTorch — use weights_only=True (safe mode, PyTorch ≥ 2.0)
+        try:
+            import torch  # type: ignore[import]
+            # weights_only=True restricts unpickling to tensor types only
+            return torch.load(str(path), map_location="cpu", weights_only=True)
+        except ImportError:
+            pass
+
+        # 3. NumPy .npy / .npz — never uses pickle for data arrays
+        try:
+            import numpy as np  # type: ignore[import]
+            if path.suffix.lower() in (".npy", ".npz"):
+                return np.load(str(path), allow_pickle=False)
+        except ImportError:
+            pass
+
+        # 4. Fall back to allow-list pickle
+        raw = path.read_bytes()
+        return safe_loads(raw, allowlist=self._allowlist, max_bytes=self._max_bytes)
+
+
+# ---------------------------------------------------------------------------
+# Self-tests
+# ---------------------------------------------------------------------------
+
+
+def _selftest() -> None:  # pragma: no cover
+    import os
+    import sys
+
+    # -----------------------------------------------------------------------
+    # 1. Benign data round-trips correctly
+    # -----------------------------------------------------------------------
+    payload = {"key": [1, 2, 3], "nested": {"a": True, "b": None}}
+    assert safe_loads(safe_dumps(payload)) == payload
+
+    # -----------------------------------------------------------------------
+    # 2. Malicious pickle is blocked
+    # -----------------------------------------------------------------------
+    class _RCEPayload:
+        """Simulate an attacker payload that would run os.system."""
+        def __reduce__(self):
+            return (os.system, ("echo pwned",))
+
+    evil_bytes = pickle.dumps(_RCEPayload())
+    try:
+        safe_loads(evil_bytes)
+        raise AssertionError("RCE payload was NOT blocked!")
+    except PickleSecurityError:
+        pass
+
+    # -----------------------------------------------------------------------
+    # 3. Oversized payload is rejected before deserialization
+    # -----------------------------------------------------------------------
+    big = pickle.dumps(b"x" * 1000)
+    try:
+        safe_loads(big, max_bytes=10)
+        raise AssertionError("Oversized payload was NOT rejected!")
+    except PickleSecurityError:
+        pass
+
+    # -----------------------------------------------------------------------
+    # 4. JSON round-trip
+    # -----------------------------------------------------------------------
+    raw = b'{"hello": "world", "nums": [1, 2, 3]}'
+    obj = safe_json_roundtrip(raw)
+    assert obj == {"hello": "world", "nums": [1, 2, 3]}
+
+    # -----------------------------------------------------------------------
+    # 5. YAML safe_load rejects object construction
+    # -----------------------------------------------------------------------
+    if _yaml is not None:
+        try:
+            safe_yaml_load("!!python/object/apply:os.system ['id']")
+            # safe_load should either raise or return a string, never execute
+        except Exception:
+            pass  # Expected: constructor error
+
+    print("pickle_rce_fix: all self-tests passed", file=sys.stderr)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    _selftest()

--- a/tests/test_pickle_rce_fix.py
+++ b/tests/test_pickle_rce_fix.py
@@ -1,0 +1,364 @@
+"""
+Regression tests for Issue #325: Remote Code Execution via Unsafe Pickle Deserialization.
+
+These tests verify that:
+  - The SafeUnpickler blocks untrusted class instantiation (RCE payloads).
+  - Allow-listed types round-trip correctly.
+  - Oversized payloads are rejected before deserialization begins.
+  - JSON is parsed safely via safe_json_roundtrip.
+  - YAML is loaded via safe_load (not the unsafe bare yaml.load).
+  - SafeModelLoader refuses checkpoints that exceed the size limit.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import pickle
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from fixes.pickle_rce_fix import (
+    PICKLE_ALLOWLIST,
+    PickleSecurityError,
+    SafeModelLoader,
+    SafeUnpickler,
+    safe_dumps,
+    safe_json_roundtrip,
+    safe_loads,
+    to_json_bytes,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_evil_pickle() -> bytes:
+    """Craft a pickle payload that would execute os.system('id') if loaded."""
+
+    class _Exploit:
+        def __reduce__(self):
+            return (os.system, ("id",))
+
+    return pickle.dumps(_Exploit())
+
+
+def _make_evil_yaml() -> str:
+    """Craft a YAML document that would invoke os.system via yaml.load."""
+    return "!!python/object/apply:os.system ['id']"
+
+
+# ---------------------------------------------------------------------------
+# SafeUnpickler / safe_loads — RCE prevention
+# ---------------------------------------------------------------------------
+
+
+class TestSafeLoadsBlocksRCE:
+    """Untrusted pickle payloads must raise PickleSecurityError, never execute."""
+
+    def test_blocks_os_system_payload(self):
+        evil = _make_evil_pickle()
+        with pytest.raises(PickleSecurityError, match="not permitted"):
+            safe_loads(evil)
+
+    def test_blocks_subprocess_payload(self):
+        import subprocess
+
+        class _SubExploit:
+            def __reduce__(self):
+                return (subprocess.check_output, (["id"],))
+
+        evil = pickle.dumps(_SubExploit())
+        with pytest.raises(PickleSecurityError):
+            safe_loads(evil)
+
+    def test_blocks_eval_payload(self):
+        """Payloads that try to reach builtins.eval must be blocked."""
+
+        class _EvalExploit:
+            def __reduce__(self):
+                return (eval, ("1+1",))
+
+        evil = pickle.dumps(_EvalExploit())
+        with pytest.raises(PickleSecurityError):
+            safe_loads(evil)
+
+    def test_blocks_exec_payload(self):
+        class _ExecExploit:
+            def __reduce__(self):
+                return (exec, ("import os; os.system('id')",))
+
+        evil = pickle.dumps(_ExecExploit())
+        with pytest.raises(PickleSecurityError):
+            safe_loads(evil)
+
+    def test_blocks_open_payload(self):
+        class _OpenExploit:
+            def __reduce__(self):
+                return (open, ("/etc/passwd",))
+
+        evil = pickle.dumps(_OpenExploit())
+        with pytest.raises(PickleSecurityError):
+            safe_loads(evil)
+
+    def test_blocks_arbitrary_class(self):
+        """A module-level class not in the allow-list must be rejected."""
+        import collections
+
+        # OrderedDict *is* in the default allow-list; use a stripped
+        # allow-list to prove find_class is exercised and rejection works.
+        obj = collections.Counter({"a": 1, "b": 2})
+        data = pickle.dumps(obj)
+        # Counter is NOT in PICKLE_ALLOWLIST — must be rejected by default
+        with pytest.raises(PickleSecurityError):
+            safe_loads(data)
+
+    def test_error_message_names_blocked_module(self):
+        evil = _make_evil_pickle()
+        with pytest.raises(PickleSecurityError) as exc_info:
+            safe_loads(evil)
+        assert "posix" in str(exc_info.value) or "os" in str(exc_info.value) or "not permitted" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# SafeUnpickler — allow-listed types
+# ---------------------------------------------------------------------------
+
+
+class TestSafeLoadsAllowList:
+    """Allow-listed types must round-trip without errors."""
+
+    @pytest.mark.parametrize(
+        "obj",
+        [
+            {"a": 1, "b": [True, None, 3.14]},
+            [1, "two", 3, {"nested": "dict"}],
+            (1, 2, 3),
+            frozenset({1, 2, 3}),
+            b"raw bytes",
+            bytearray(b"mutable bytes"),
+            42,
+            3.14,
+            True,
+            None,
+        ],
+    )
+    def test_primitive_roundtrip(self, obj):
+        assert safe_loads(safe_dumps(obj)) == obj
+
+    def test_nested_dict_roundtrip(self):
+        obj = {"level1": {"level2": {"level3": [1, 2, 3]}}}
+        assert safe_loads(safe_dumps(obj)) == obj
+
+    def test_empty_structures(self):
+        for empty in [{}, [], (), set(), frozenset()]:
+            assert safe_loads(safe_dumps(empty)) == empty
+
+
+# ---------------------------------------------------------------------------
+# Size limit enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestSizeLimit:
+    """Oversized payloads must be rejected before deserialization."""
+
+    def test_rejects_oversized_payload(self):
+        data = pickle.dumps(b"x" * 1000)
+        with pytest.raises(PickleSecurityError, match="exceeds"):
+            safe_loads(data, max_bytes=10)
+
+    def test_accepts_within_size_limit(self):
+        data = safe_dumps({"key": "value"})
+        result = safe_loads(data, max_bytes=10 * 1024)
+        assert result == {"key": "value"}
+
+    def test_wrong_input_type_raises_type_error(self):
+        with pytest.raises(TypeError):
+            safe_loads("not bytes")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Custom allow-list
+# ---------------------------------------------------------------------------
+
+
+class TestCustomAllowList:
+    """Users can supply a narrower or wider allow-list."""
+
+    def test_empty_allowlist_blocks_everything(self):
+        import datetime
+
+        # Use datetime.date which requires find_class; empty allowlist must block it
+        data = safe_dumps(datetime.date(2025, 1, 1))
+        with pytest.raises(PickleSecurityError):
+            safe_loads(data, allowlist=frozenset())
+
+    def test_custom_allowlist_permits_specific_type(self):
+        import datetime
+
+        obj = datetime.date(2025, 1, 1)
+        data = safe_dumps(obj)
+        custom = frozenset({("datetime", "date")})
+        result = safe_loads(data, allowlist=custom)
+        assert result == obj
+
+
+# ---------------------------------------------------------------------------
+# JSON helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSafeJsonRoundtrip:
+    """JSON parsing must never execute code."""
+
+    def test_parses_dict(self):
+        raw = b'{"hello": "world"}'
+        assert safe_json_roundtrip(raw) == {"hello": "world"}
+
+    def test_parses_list(self):
+        assert safe_json_roundtrip(b"[1, 2, 3]") == [1, 2, 3]
+
+    def test_parses_string_input(self):
+        assert safe_json_roundtrip('{"x": 1}') == {"x": 1}
+
+    def test_rejects_oversized_json(self):
+        big = json.dumps({"a": "b" * 1000}).encode()
+        with pytest.raises(PickleSecurityError, match="exceeds"):
+            safe_json_roundtrip(big, max_bytes=100)
+
+    def test_raises_on_invalid_json(self):
+        with pytest.raises((json.JSONDecodeError, ValueError)):
+            safe_json_roundtrip(b"not valid json }{")
+
+    def test_to_json_bytes_roundtrip(self):
+        obj = {"nums": [1, 2, 3], "flag": True}
+        assert json.loads(to_json_bytes(obj)) == obj
+
+
+# ---------------------------------------------------------------------------
+# YAML helper
+# ---------------------------------------------------------------------------
+
+
+class TestSafeYamlLoad:
+    """yaml.safe_load must be used; !!python/* tags must raise, not execute."""
+
+    @pytest.fixture(autouse=True)
+    def skip_if_no_yaml(self):
+        pytest.importorskip("yaml")
+
+    def test_safe_load_parses_plain_yaml(self):
+        from fixes.pickle_rce_fix import safe_yaml_load
+
+        doc = "key: value\nnested:\n  - 1\n  - 2\n"
+        result = safe_yaml_load(doc)
+        assert result == {"key": "value", "nested": [1, 2]}
+
+    def test_safe_load_rejects_python_object_tag(self):
+        from yaml import YAMLError
+
+        from fixes.pickle_rce_fix import safe_yaml_load
+
+        evil = _make_evil_yaml()
+        # yaml.safe_load raises ConstructorError for !!python/* tags
+        with pytest.raises((YAMLError, Exception)):
+            safe_yaml_load(evil)
+
+    def test_safe_load_parses_bytes(self):
+        from fixes.pickle_rce_fix import safe_yaml_load
+
+        result = safe_yaml_load(b"answer: 42")
+        assert result == {"answer": 42}
+
+    def test_safe_load_accepts_file_like(self):
+        from fixes.pickle_rce_fix import safe_yaml_load
+
+        stream = io.StringIO("hello: world")
+        assert safe_yaml_load(stream) == {"hello": "world"}
+
+
+# ---------------------------------------------------------------------------
+# SafeModelLoader
+# ---------------------------------------------------------------------------
+
+
+class TestSafeModelLoader:
+    """Model checkpoints must never be loaded via unsafe pickle."""
+
+    def test_loads_json_checkpoint(self):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+            json.dump({"weights": [0.1, 0.2, 0.3]}, f)
+            path = f.name
+        try:
+            loader = SafeModelLoader()
+            result = loader.load_checkpoint(path)
+            assert result == {"weights": [0.1, 0.2, 0.3]}
+        finally:
+            os.unlink(path)
+
+    def test_rejects_oversized_file(self):
+        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+            f.write(safe_dumps({"ok": True}))
+            path = f.name
+        try:
+            loader = SafeModelLoader(max_bytes=5)  # tiny limit
+            with pytest.raises(PickleSecurityError, match="exceeds"):
+                loader.load_checkpoint(path)
+        finally:
+            os.unlink(path)
+
+    def test_raises_file_not_found(self):
+        loader = SafeModelLoader()
+        with pytest.raises(FileNotFoundError):
+            loader.load_checkpoint("/tmp/nonexistent_claw_test_325.pkl")
+
+    def test_loads_safe_pickle_checkpoint(self):
+        data = {"layer1": [1.0, 2.0], "layer2": [3.0, 4.0]}
+        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+            f.write(safe_dumps(data))
+            path = f.name
+        try:
+            loader = SafeModelLoader()
+            result = loader.load_checkpoint(path)
+            assert result == data
+        finally:
+            os.unlink(path)
+
+    def test_blocks_rce_pickle_checkpoint(self):
+        """A malicious .pkl file must be rejected by the loader."""
+        evil = _make_evil_pickle()
+        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+            f.write(evil)
+            path = f.name
+        try:
+            loader = SafeModelLoader()
+            with pytest.raises(PickleSecurityError):
+                loader.load_checkpoint(path)
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# SafeUnpickler direct usage
+# ---------------------------------------------------------------------------
+
+
+class TestSafeUnpicklerDirect:
+    """Direct SafeUnpickler usage mirrors safe_loads behaviour."""
+
+    def test_direct_usage(self):
+        data = pickle.dumps({"direct": True})
+        unpickler = SafeUnpickler(io.BytesIO(data))
+        result = unpickler.load()
+        assert result == {"direct": True}
+
+    def test_direct_blocks_os_module(self):
+        evil = _make_evil_pickle()
+        unpickler = SafeUnpickler(io.BytesIO(evil))
+        with pytest.raises(PickleSecurityError):
+            unpickler.load()


### PR DESCRIPTION
## Fix: Remote Code Execution via Unsafe Pickle Deserialization

/claim #325

### Root Cause

Python's `pickle` module executes arbitrary code during deserialization. Any call to `pickle.loads(untrusted_data)` is equivalent to RCE — an attacker can craft a payload that runs `os.system`, `subprocess`, `eval`, or `exec` on the server.

### Changes

**`fixes/pickle_rce_fix.py`** — provides drop-in safe replacements:

| Unsafe | Safe Alternative |
|---|---|
| `pickle.loads(untrusted)` | `safe_loads()` with strict allow-list via `SafeUnpickler` |
| `yaml.load(stream)` | `safe_yaml_load()` — always uses `yaml.safe_load` |
| `torch.load(path)` | `SafeModelLoader.load_checkpoint()` with `weights_only=True` |
| Unconstrained pickle files | Size-limited, allow-listed deserialization |

Key design decisions:
- **SafeUnpickler**: overrides `find_class()` — blocks any module/class not in `PICKLE_ALLOWLIST`. RCE payloads targeting `os.system`, `subprocess`, `eval`, `exec`, `open` etc. all raise `PickleSecurityError` before execution.
- **JSON preferred**: `safe_json_roundtrip()` for all plain data — zero deserialization risk.
- **Size limits**: Oversized payloads rejected before deserialization begins (DoS prevention).
- **ML checkpoints**: `SafeModelLoader` routes to JSON → `torch.load(weights_only=True)` → `numpy.load(allow_pickle=False)` → allow-listed unpickler.

**`tests/test_pickle_rce_fix.py`** — 41 regression tests covering:
- RCE payloads: `os.system`, `subprocess`, `eval`, `exec`, `open`
- Allow-listed types round-trip correctly
- Oversized payload rejection
- Custom allow-list behaviour
- JSON helpers
- YAML safe loading (rejects `!!python/*` tags)
- SafeModelLoader (JSON, pickle, RCE blocking, size limits)

### Test Results

```
41 passed in 0.04s
```

### Demo

![Demo](https://github.com/GoThundercats/ai-research/releases/download/demo-1783174230/demo_ai-research_325.gif)

---

*Fixes #325*