### PR TITLE
fix: add safe YAML config loader

### DIFF
--- a/fixes/yaml_safe_config_loader.py
+++ b/fixes/yaml_safe_config_loader.py
@@ -1,0 +1,135 @@
+"""Safe YAML configuration loading for issue #341.
+
+Unsafe PyYAML loaders such as ``yaml.Loader`` and ``yaml.UnsafeLoader`` can
+construct arbitrary Python objects from tags like ``!!python/object/apply``.
+If a configuration endpoint accepts untrusted YAML and uses one of those
+loaders, a payload can execute code during parsing.
+
+This module provides a small, framework-agnostic replacement for config
+parsers:
+
+* parse with ``yaml.SafeLoader`` semantics only;
+* reject aliases/anchors so YAML expansion cannot create parser bombs;
+* enforce a byte limit and node limit before returning data;
+* optionally require the top-level value to be a mapping, as config files
+  normally should be.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, TextIO
+
+import yaml
+from yaml.events import AliasEvent
+
+
+DEFAULT_MAX_BYTES = 128 * 1024
+DEFAULT_MAX_NODES = 10_000
+
+
+class YamlConfigError(ValueError):
+    """Raised when a YAML config is unsafe or has an invalid shape."""
+
+
+class _BoundedSafeLoader(yaml.SafeLoader):
+    """SafeLoader with alias rejection and a simple node budget."""
+
+    def __init__(self, stream: str, *, max_nodes: int) -> None:
+        super().__init__(stream)
+        self._max_nodes = max_nodes
+        self._node_count = 0
+
+    def compose_node(self, parent: Any, index: Any) -> yaml.Node:
+        if self.check_event(AliasEvent):
+            raise YamlConfigError("YAML aliases and anchors are not allowed")
+
+        self._node_count += 1
+        if self._node_count > self._max_nodes:
+            raise YamlConfigError("YAML document exceeds the node limit")
+
+        return super().compose_node(parent, index)
+
+
+def _read_yaml_text(source: str | bytes | TextIO) -> str:
+    if hasattr(source, "read"):
+        source = source.read()  # type: ignore[assignment]
+
+    if isinstance(source, bytes):
+        try:
+            return source.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise YamlConfigError("YAML config must be valid UTF-8") from exc
+
+    if not isinstance(source, str):
+        raise YamlConfigError("YAML config must be text, bytes, or a text stream")
+
+    return source
+
+
+def load_yaml_config(
+    source: str | bytes | TextIO,
+    *,
+    require_mapping: bool = True,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+    max_nodes: int = DEFAULT_MAX_NODES,
+) -> dict[str, Any] | list[Any] | str | int | float | bool | None:
+    """Parse YAML configuration without executing Python object tags.
+
+    ``yaml.load`` is used only with a ``yaml.SafeLoader`` subclass so the
+    parser never constructs arbitrary Python objects. Unknown or Python-specific
+    tags raise ``YamlConfigError`` instead of being evaluated.
+    """
+
+    text = _read_yaml_text(source)
+    if len(text.encode("utf-8")) > max_bytes:
+        raise YamlConfigError("YAML config exceeds the byte limit")
+
+    class Loader(_BoundedSafeLoader):
+        def __init__(self, stream: str) -> None:
+            super().__init__(stream, max_nodes=max_nodes)
+
+    try:
+        parsed = yaml.load(text, Loader=Loader)
+    except YamlConfigError:
+        raise
+    except yaml.YAMLError as exc:
+        raise YamlConfigError("YAML config is invalid or contains unsafe tags") from exc
+
+    if parsed is None:
+        parsed = {}
+
+    if require_mapping and not isinstance(parsed, dict):
+        raise YamlConfigError("YAML config must be a mapping at the top level")
+
+    return parsed
+
+
+def load_yaml_config_file(
+    path: str | Path,
+    *,
+    require_mapping: bool = True,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+    max_nodes: int = DEFAULT_MAX_NODES,
+) -> dict[str, Any] | list[Any] | str | int | float | bool | None:
+    """Read and safely parse a YAML config file."""
+
+    config_path = Path(path)
+    if config_path.stat().st_size > max_bytes:
+        raise YamlConfigError("YAML config exceeds the byte limit")
+
+    return load_yaml_config(
+        config_path.read_bytes(),
+        require_mapping=require_mapping,
+        max_bytes=max_bytes,
+        max_nodes=max_nodes,
+    )
+
+
+__all__ = [
+    "DEFAULT_MAX_BYTES",
+    "DEFAULT_MAX_NODES",
+    "YamlConfigError",
+    "load_yaml_config",
+    "load_yaml_config_file",
+]

--- a/tests/test_yaml_safe_config_loader.py
+++ b/tests/test_yaml_safe_config_loader.py
@@ -1,0 +1,77 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from fixes.yaml_safe_config_loader import YamlConfigError, load_yaml_config, load_yaml_config_file
+
+
+class TestYamlSafeConfigLoader(unittest.TestCase):
+    def test_loads_normal_mapping_config(self):
+        parsed = load_yaml_config(
+            """
+            service:
+              host: 127.0.0.1
+              port: 8080
+            features:
+              audit: true
+            """
+        )
+
+        self.assertEqual(parsed["service"]["port"], 8080)
+        self.assertIs(parsed["features"]["audit"], True)
+
+    def test_empty_config_returns_empty_mapping(self):
+        self.assertEqual(load_yaml_config(""), {})
+
+    def test_rejects_python_object_apply_tag(self):
+        payload = '!!python/object/apply:os.system ["echo should-not-run"]'
+
+        with self.assertRaises(YamlConfigError):
+            load_yaml_config(payload, require_mapping=False)
+
+    def test_rejects_python_name_tag(self):
+        payload = "dangerous: !!python/name:os.system"
+
+        with self.assertRaises(YamlConfigError):
+            load_yaml_config(payload)
+
+    def test_rejects_alias_expansion(self):
+        payload = """
+        base: &base
+          enabled: true
+        copy: *base
+        """
+
+        with self.assertRaisesRegex(YamlConfigError, "aliases"):
+            load_yaml_config(payload)
+
+    def test_rejects_top_level_sequence_for_config(self):
+        with self.assertRaisesRegex(YamlConfigError, "top level"):
+            load_yaml_config("- one\n- two\n")
+
+    def test_allows_non_mapping_when_explicitly_requested(self):
+        self.assertEqual(
+            load_yaml_config("- one\n- two\n", require_mapping=False),
+            ["one", "two"],
+        )
+
+    def test_rejects_oversized_input(self):
+        with self.assertRaisesRegex(YamlConfigError, "byte limit"):
+            load_yaml_config("x: " + ("a" * 20), max_bytes=8)
+
+    def test_rejects_document_that_exceeds_node_budget(self):
+        payload = "\n".join(f"k{i}: {i}" for i in range(20))
+
+        with self.assertRaisesRegex(YamlConfigError, "node limit"):
+            load_yaml_config(payload, max_nodes=5)
+
+    def test_loads_from_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "config.yaml"
+            path.write_text("mode: safe\n", encoding="utf-8")
+
+            self.assertEqual(load_yaml_config_file(path), {"mode": "safe"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #341

## Summary

- Adds a safe YAML configuration loader that never uses `yaml.Loader`, `yaml.UnsafeLoader`, or `yaml.FullLoader`.
- Uses `yaml.SafeLoader` semantics with byte and node budgets.
- Rejects YAML aliases/anchors so alias expansion cannot become a parser bomb.
- Wraps unsafe Python-specific tags such as `!!python/object/apply` and `!!python/name` in a stable `YamlConfigError`.
- Optionally enforces a top-level mapping shape for normal config files.
- Adds dependency-light `unittest` coverage for normal parsing, unsafe tags, aliases, size limits, node limits, and file loading.

## Verification

```text
python -m unittest tests.test_yaml_safe_config_loader -v
python -m py_compile fixes\yaml_safe_config_loader.py tests\test_yaml_safe_config_loader.py
git diff --check
```

Result: 10 tests passed; syntax and whitespace checks passed.

## Bounty

This is a submission for the `$100` bounty in #341. Payment details are available on request after review/acceptance.
