### PR TITLE
fix: break XSS CSRF account takeover chain

### DIFF
--- a/fixes/xss_csrf_account_takeover_fix.py
+++ b/fixes/xss_csrf_account_takeover_fix.py
@@ -1,0 +1,133 @@
+"""Defense-in-depth fix for issue #343: XSS to CSRF account takeover.
+
+The vulnerable chain has three links:
+
+* reflected or stored user content renders as executable HTML/JavaScript;
+* state-changing account actions accept cross-site requests without a token;
+* login keeps an attacker-controlled session identifier alive.
+
+This module provides framework-neutral helpers that break those links without
+depending on a specific web framework.
+"""
+
+from __future__ import annotations
+
+import html
+import hmac
+import secrets
+from collections.abc import Callable, MutableMapping
+from dataclasses import dataclass
+from typing import Any
+
+
+class AccountTakeoverGuardError(ValueError):
+    """Raised when a request fails account takeover protections."""
+
+
+def escape_html(value: Any) -> str:
+    """Encode untrusted content before inserting it into an HTML response."""
+
+    return html.escape(str(value), quote=True)
+
+
+def render_profile_heading(display_name: Any) -> str:
+    """Render profile data without allowing script execution."""
+
+    return f"<h1>{escape_html(display_name)}</h1>"
+
+
+def generate_csrf_token() -> str:
+    """Return a high-entropy CSRF token suitable for storing in a session."""
+
+    return secrets.token_urlsafe(32)
+
+
+def validate_csrf_token(session_token: str | None, submitted_token: str | None) -> None:
+    """Reject missing or mismatched CSRF tokens using constant-time compare."""
+
+    if not session_token or not submitted_token:
+        raise AccountTakeoverGuardError("Missing CSRF token")
+    if not hmac.compare_digest(session_token, submitted_token):
+        raise AccountTakeoverGuardError("Invalid CSRF token")
+
+
+def rotate_session_on_login(
+    session: MutableMapping[str, Any],
+    *,
+    user_id: str,
+    token_factory: Callable[[], str] = generate_csrf_token,
+) -> None:
+    """Clear fixation-prone state and bind a fresh CSRF token to the login.
+
+    Most frameworks regenerate the cookie identifier through their session
+    backend. The portable part shown here is still important: remove stale
+    attacker-controlled values and issue a new authenticated session context.
+    """
+
+    session.clear()
+    session["user_id"] = user_id
+    session["csrf_token"] = token_factory()
+    session["authenticated"] = True
+
+
+@dataclass
+class Account:
+    """Minimal account model used by the safe account-update helper."""
+
+    user_id: str
+    email: str
+    display_name: str
+
+
+def update_account_email(
+    *,
+    account: Account,
+    session: MutableMapping[str, Any],
+    submitted_csrf_token: str | None,
+    new_email: str,
+) -> Account:
+    """Apply an account email change only for the logged-in owner with CSRF.
+
+    This protects the high-impact state change that turns XSS plus CSRF into
+    account takeover. The stored email remains plain data; HTML encoding is
+    applied at render time, not by mutating persisted values.
+    """
+
+    if session.get("user_id") != account.user_id:
+        raise AccountTakeoverGuardError("Authenticated user does not own account")
+
+    validate_csrf_token(
+        str(session.get("csrf_token") or ""),
+        submitted_csrf_token,
+    )
+
+    normalized_email = new_email.strip()
+    if "@" not in normalized_email or len(normalized_email) > 254:
+        raise AccountTakeoverGuardError("Invalid email")
+
+    account.email = normalized_email
+    return account
+
+
+def secure_session_cookie_options(*, https_only: bool = True) -> dict[str, Any]:
+    """Return session-cookie flags that reduce XSS and CSRF blast radius."""
+
+    return {
+        "httponly": True,
+        "secure": https_only,
+        "samesite": "Strict",
+        "path": "/",
+    }
+
+
+__all__ = [
+    "Account",
+    "AccountTakeoverGuardError",
+    "escape_html",
+    "generate_csrf_token",
+    "render_profile_heading",
+    "rotate_session_on_login",
+    "secure_session_cookie_options",
+    "update_account_email",
+    "validate_csrf_token",
+]

--- a/tests/test_xss_csrf_account_takeover_fix.py
+++ b/tests/test_xss_csrf_account_takeover_fix.py
@@ -1,0 +1,116 @@
+"""Tests for the issue #343 XSS to CSRF account takeover fix."""
+
+from __future__ import annotations
+
+import unittest
+
+from fixes.xss_csrf_account_takeover_fix import (
+    Account,
+    AccountTakeoverGuardError,
+    escape_html,
+    render_profile_heading,
+    rotate_session_on_login,
+    secure_session_cookie_options,
+    update_account_email,
+    validate_csrf_token,
+)
+
+
+class XssCsrfAccountTakeoverFixTests(unittest.TestCase):
+    def test_escape_html_encodes_script_payload(self) -> None:
+        payload = '<script>alert("owned")</script>'
+
+        escaped = escape_html(payload)
+
+        self.assertNotIn("<script>", escaped)
+        self.assertIn("&lt;script&gt;", escaped)
+        self.assertIn("&quot;owned&quot;", escaped)
+
+    def test_render_profile_heading_does_not_emit_executable_html(self) -> None:
+        html = render_profile_heading("<img src=x onerror=alert(1)>")
+
+        self.assertEqual(html, "<h1>&lt;img src=x onerror=alert(1)&gt;</h1>")
+
+    def test_csrf_token_validation_accepts_matching_token(self) -> None:
+        validate_csrf_token("known-token", "known-token")
+
+    def test_csrf_token_validation_rejects_missing_or_mismatched_token(self) -> None:
+        with self.assertRaises(AccountTakeoverGuardError):
+            validate_csrf_token("known-token", None)
+        with self.assertRaises(AccountTakeoverGuardError):
+            validate_csrf_token("known-token", "wrong-token")
+
+    def test_rotate_session_on_login_clears_fixation_state(self) -> None:
+        session = {
+            "csrf_token": "attacker-token",
+            "cart_id": "prelogin-state",
+            "user_id": "attacker",
+        }
+
+        rotate_session_on_login(
+            session,
+            user_id="victim",
+            token_factory=lambda: "fresh-token",
+        )
+
+        self.assertEqual(
+            session,
+            {
+                "authenticated": True,
+                "csrf_token": "fresh-token",
+                "user_id": "victim",
+            },
+        )
+
+    def test_update_account_email_requires_owner_session(self) -> None:
+        account = Account("victim", "old@example.com", "Victim")
+        session = {"user_id": "attacker", "csrf_token": "valid-token"}
+
+        with self.assertRaises(AccountTakeoverGuardError):
+            update_account_email(
+                account=account,
+                session=session,
+                submitted_csrf_token="valid-token",
+                new_email="attacker@example.com",
+            )
+
+        self.assertEqual(account.email, "old@example.com")
+
+    def test_update_account_email_requires_csrf_for_state_change(self) -> None:
+        account = Account("victim", "old@example.com", "Victim")
+        session = {"user_id": "victim", "csrf_token": "valid-token"}
+
+        with self.assertRaises(AccountTakeoverGuardError):
+            update_account_email(
+                account=account,
+                session=session,
+                submitted_csrf_token="stolen-or-missing",
+                new_email="attacker@example.com",
+            )
+
+        self.assertEqual(account.email, "old@example.com")
+
+    def test_update_account_email_allows_owner_with_valid_csrf(self) -> None:
+        account = Account("victim", "old@example.com", "Victim")
+        session = {"user_id": "victim", "csrf_token": "valid-token"}
+
+        updated = update_account_email(
+            account=account,
+            session=session,
+            submitted_csrf_token="valid-token",
+            new_email=" new@example.com ",
+        )
+
+        self.assertIs(updated, account)
+        self.assertEqual(account.email, "new@example.com")
+
+    def test_secure_cookie_options_reduce_chain_blast_radius(self) -> None:
+        options = secure_session_cookie_options()
+
+        self.assertTrue(options["httponly"])
+        self.assertTrue(options["secure"])
+        self.assertEqual(options["samesite"], "Strict")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #343

## Summary

- Adds a framework-neutral guard module for the full XSS-to-CSRF account takeover chain.
- Encodes untrusted profile/display content before HTML rendering.
- Requires constant-time CSRF token validation before state-changing account email updates.
- Rotates login session state and issues a fresh CSRF token to reduce session fixation risk.
- Provides strict session cookie defaults: HttpOnly, Secure, SameSite=Strict.
- Adds standard-library `unittest` coverage for XSS encoding, CSRF rejection, owner checks, session rotation, and valid-account updates.

## Verification

```text
python -m unittest tests.test_xss_csrf_account_takeover_fix -v
python -m py_compile fixes\xss_csrf_account_takeover_fix.py tests\test_xss_csrf_account_takeover_fix.py
git diff --check
```

Result: 9 tests passed; syntax and whitespace checks passed.

## Bounty

This is a submission for the `$100` bounty in #343. Payment details are available on request after review/acceptance.
