### PR TITLE
fix: harden path and log handling

### DIFF
--- a/fixes/path_traversal_log_poisoning_fix.py
+++ b/fixes/path_traversal_log_poisoning_fix.py
@@ -1,0 +1,126 @@
+"""Defense-in-depth fix for issue #334: path traversal plus log poisoning.
+
+The vulnerable chain has two parts:
+
+* user-controlled file paths escape an intended base directory; and
+* attacker-controlled log fields inject new log lines or terminal controls.
+
+This module provides framework-neutral helpers for resolving paths under a
+trusted root and emitting single-line structured log records.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote
+
+
+class PathTraversalLogPoisoningError(ValueError):
+    """Raised when path or log input fails security validation."""
+
+
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+_LOG_KEY = re.compile(r"^[A-Za-z0-9_.-]{1,64}$")
+_MAX_DECODE_PASSES = 3
+
+
+def _decode_path(value: str) -> str:
+    """Decode repeated URL encoding so %252e%252e%252f cannot bypass checks."""
+
+    decoded = value
+    for _ in range(_MAX_DECODE_PASSES):
+        next_value = unquote(decoded)
+        if next_value == decoded:
+            break
+        decoded = next_value
+    return decoded
+
+
+def resolve_safe_path(base_dir: str | Path, user_path: str) -> Path:
+    """Return a resolved path only when it stays under ``base_dir``.
+
+    The function rejects absolute paths, drive-qualified paths, traversal
+    segments, null bytes, and URL-encoded traversal attempts before resolving
+    the final target. The target does not need to exist, which keeps the helper
+    useful for safe write paths as well as reads.
+    """
+
+    if not user_path or "\x00" in user_path:
+        raise PathTraversalLogPoisoningError("Invalid path")
+
+    decoded = _decode_path(user_path).replace("\\", "/")
+    candidate_user_path = Path(decoded)
+
+    if candidate_user_path.is_absolute() or candidate_user_path.drive:
+        raise PathTraversalLogPoisoningError("Absolute paths are not allowed")
+
+    if any(part in {"", ".", ".."} for part in decoded.split("/")):
+        raise PathTraversalLogPoisoningError("Path traversal is not allowed")
+
+    root = Path(base_dir).resolve()
+    candidate = (root / candidate_user_path).resolve()
+
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise PathTraversalLogPoisoningError("Path escapes base directory") from exc
+
+    return candidate
+
+
+def read_text_under_base(
+    base_dir: str | Path,
+    user_path: str,
+    *,
+    encoding: str = "utf-8",
+    max_bytes: int = 1024 * 1024,
+) -> str:
+    """Safely read a text file from an allowed base directory.
+
+    Size limiting prevents an attacker from using a legitimate in-tree path as
+    a resource exhaustion primitive after traversal has been blocked.
+    """
+
+    target = resolve_safe_path(base_dir, user_path)
+    if not target.is_file():
+        raise PathTraversalLogPoisoningError("File does not exist")
+    if target.stat().st_size > max_bytes:
+        raise PathTraversalLogPoisoningError("File exceeds maximum size")
+    return target.read_text(encoding=encoding)
+
+
+def sanitize_log_value(value: Any, *, max_length: int = 2048) -> str:
+    """Return a log-safe string without raw controls or injected new lines."""
+
+    text = str(value)
+    text = _CONTROL_CHARS.sub(lambda match: f"\\u{ord(match.group(0)):04x}", text)
+    if len(text) > max_length:
+        return text[:max_length] + "...[truncated]"
+    return text
+
+
+def structured_log_line(event: str, **fields: Any) -> str:
+    """Build a single-line JSON log entry from untrusted field values."""
+
+    if not _LOG_KEY.fullmatch(event):
+        raise PathTraversalLogPoisoningError("Invalid event name")
+
+    record: dict[str, Any] = {"event": event}
+    for key, value in fields.items():
+        if not _LOG_KEY.fullmatch(key):
+            raise PathTraversalLogPoisoningError(f"Invalid log field: {key}")
+        record[key] = sanitize_log_value(value)
+
+    return json.dumps(record, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+
+
+__all__ = [
+    "PathTraversalLogPoisoningError",
+    "read_text_under_base",
+    "resolve_safe_path",
+    "sanitize_log_value",
+    "structured_log_line",
+]

--- a/tests/test_path_traversal_log_poisoning_fix.py
+++ b/tests/test_path_traversal_log_poisoning_fix.py
@@ -1,0 +1,91 @@
+"""Tests for issue #334 path traversal and log poisoning hardening."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from fixes.path_traversal_log_poisoning_fix import (
+    PathTraversalLogPoisoningError,
+    read_text_under_base,
+    resolve_safe_path,
+    sanitize_log_value,
+    structured_log_line,
+)
+
+
+class PathTraversalLogPoisoningFixTests(unittest.TestCase):
+    def test_resolve_safe_path_allows_in_tree_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            (base / "public").mkdir()
+            target = base / "public" / "report.txt"
+            target.write_text("safe", encoding="utf-8")
+
+            resolved = resolve_safe_path(base, "public/report.txt")
+
+            self.assertEqual(resolved, target.resolve())
+
+    def test_resolve_safe_path_rejects_parent_traversal(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(PathTraversalLogPoisoningError):
+                resolve_safe_path(tmp, "../secret.txt")
+
+    def test_resolve_safe_path_rejects_url_encoded_traversal(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(PathTraversalLogPoisoningError):
+                resolve_safe_path(tmp, "%252e%252e%252fsecret.txt")
+
+    def test_resolve_safe_path_rejects_absolute_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            absolute = str(Path(tmp).resolve() / "secret.txt")
+
+            with self.assertRaises(PathTraversalLogPoisoningError):
+                resolve_safe_path(tmp, absolute)
+
+    def test_read_text_under_base_reads_allowed_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            (base / "docs").mkdir()
+            (base / "docs" / "note.txt").write_text("hello", encoding="utf-8")
+
+            content = read_text_under_base(base, "docs/note.txt")
+
+            self.assertEqual(content, "hello")
+
+    def test_read_text_under_base_rejects_missing_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(PathTraversalLogPoisoningError):
+                read_text_under_base(tmp, "missing.txt")
+
+    def test_sanitize_log_value_neutralizes_newlines_and_controls(self) -> None:
+        sanitized = sanitize_log_value("ok\nlevel=admin\r\x1b[31m")
+
+        self.assertNotIn("\n", sanitized)
+        self.assertNotIn("\r", sanitized)
+        self.assertNotIn("\x1b", sanitized)
+        self.assertIn("\\u000a", sanitized)
+        self.assertIn("\\u001b", sanitized)
+
+    def test_structured_log_line_is_single_line_json(self) -> None:
+        line = structured_log_line(
+            "file_access_denied",
+            user="alice\nrole=admin",
+            path="../../etc/passwd",
+        )
+
+        self.assertNotIn("\n", line)
+        decoded = json.loads(line)
+        self.assertEqual(decoded["event"], "file_access_denied")
+        self.assertIn("\\u000a", decoded["user"])
+        self.assertEqual(decoded["path"], "../../etc/passwd")
+
+    def test_structured_log_line_rejects_untrusted_field_names(self) -> None:
+        with self.assertRaises(PathTraversalLogPoisoningError):
+            structured_log_line("file_access", **{"bad\nkey": "value"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #334

## Summary
- adds a framework-neutral helper that resolves user-supplied paths under a trusted base directory
- rejects parent traversal, absolute paths, null bytes, and repeated URL-encoded traversal attempts
- adds structured single-line JSON log output that neutralizes raw control characters and log-line injection
- includes focused unittest coverage for traversal and log poisoning cases

## Verification
- `python -m unittest tests.test_path_traversal_log_poisoning_fix -v`
- `python -m py_compile fixes\path_traversal_log_poisoning_fix.py tests\test_path_traversal_log_poisoning_fix.py`
- `git diff --check`

Payment details are available on request if this is accepted for the listed bounty.
