### PR TITLE
fix: guard websocket origin and sessions

### DIFF
--- a/fixes/websocket_origin_session_fix.py
+++ b/fixes/websocket_origin_session_fix.py
@@ -1,0 +1,125 @@
+"""Defense-in-depth fix for issue #344: CSWSH plus session prediction.
+
+Cross-Site WebSocket Hijacking happens when a browser can open an authenticated
+WebSocket from an attacker origin and cookies are accepted without an Origin
+check. If the WebSocket session identifier is also predictable, the attacker can
+reuse or guess a live channel.
+
+This module is framework-neutral. Call ``WebSocketHandshakeGuard.validate`` in
+your WebSocket upgrade handler before accepting the socket.
+"""
+
+from __future__ import annotations
+
+import hmac
+import secrets
+from dataclasses import dataclass
+from typing import Mapping
+from urllib.parse import urlsplit
+
+
+class WebSocketSecurityError(ValueError):
+    """Raised when a WebSocket handshake fails security validation."""
+
+
+def _canonical_origin(origin: str) -> str:
+    parsed = urlsplit(origin)
+    if parsed.scheme not in {"https", "wss"} or not parsed.netloc:
+        raise WebSocketSecurityError("Invalid WebSocket origin")
+    host = parsed.hostname
+    if not host:
+        raise WebSocketSecurityError("Invalid WebSocket origin host")
+    port = f":{parsed.port}" if parsed.port else ""
+    return f"{parsed.scheme}://{host.lower()}{port}"
+
+
+def generate_ws_session_id() -> str:
+    """Return a high-entropy WebSocket session identifier."""
+
+    return secrets.token_urlsafe(32)
+
+
+@dataclass(frozen=True)
+class WebSocketSession:
+    """Accepted WebSocket session metadata."""
+
+    session_id: str
+    user_id: str
+    origin: str
+    csrf_token: str
+
+
+@dataclass(frozen=True)
+class WebSocketHandshakeGuard:
+    """Validate origin, CSRF binding, and session entropy before upgrade."""
+
+    allowed_origins: frozenset[str]
+    require_csrf: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.allowed_origins:
+            raise WebSocketSecurityError("At least one allowed origin is required")
+        normalized = frozenset(_canonical_origin(origin) for origin in self.allowed_origins)
+        object.__setattr__(self, "allowed_origins", normalized)
+
+    def validate_origin(self, origin: str | None) -> str:
+        if not origin:
+            raise WebSocketSecurityError("Missing Origin header")
+        normalized = _canonical_origin(origin)
+        if normalized not in self.allowed_origins:
+            raise WebSocketSecurityError("Origin is not allowed")
+        return normalized
+
+    def validate_csrf(self, expected_token: str | None, submitted_token: str | None) -> None:
+        if not self.require_csrf:
+            return
+        if not expected_token or not submitted_token:
+            raise WebSocketSecurityError("Missing WebSocket CSRF token")
+        if not hmac.compare_digest(expected_token, submitted_token):
+            raise WebSocketSecurityError("Invalid WebSocket CSRF token")
+
+    def validate(
+        self,
+        headers: Mapping[str, str],
+        session: Mapping[str, str],
+        *,
+        session_id_factory=generate_ws_session_id,
+    ) -> WebSocketSession:
+        """Validate a WebSocket handshake and return fresh channel metadata."""
+
+        origin = self.validate_origin(headers.get("Origin") or headers.get("origin"))
+        self.validate_csrf(
+            session.get("csrf_token"),
+            headers.get("Sec-WebSocket-Protocol") or headers.get("X-CSRF-Token"),
+        )
+
+        user_id = session.get("user_id")
+        if not user_id:
+            raise WebSocketSecurityError("Missing authenticated user")
+
+        return WebSocketSession(
+            session_id=session_id_factory(),
+            user_id=user_id,
+            origin=origin,
+            csrf_token=session.get("csrf_token", ""),
+        )
+
+
+def websocket_cookie_headers(session_id: str, *, https_only: bool = True) -> dict[str, str]:
+    """Return cookie headers that keep the WebSocket session browser-bound."""
+
+    if not session_id:
+        raise WebSocketSecurityError("Missing WebSocket session id")
+    parts = [f"ws_session={session_id}", "Path=/", "HttpOnly", "SameSite=Strict"]
+    if https_only:
+        parts.append("Secure")
+    return {"Set-Cookie": "; ".join(parts)}
+
+
+__all__ = [
+    "WebSocketHandshakeGuard",
+    "WebSocketSecurityError",
+    "WebSocketSession",
+    "generate_ws_session_id",
+    "websocket_cookie_headers",
+]

--- a/tests/test_websocket_origin_session_fix.py
+++ b/tests/test_websocket_origin_session_fix.py
@@ -1,0 +1,101 @@
+"""Tests for issue #344 WebSocket origin and session hardening."""
+
+from __future__ import annotations
+
+import unittest
+
+from fixes.websocket_origin_session_fix import (
+    WebSocketHandshakeGuard,
+    WebSocketSecurityError,
+    generate_ws_session_id,
+    websocket_cookie_headers,
+)
+
+
+class WebSocketOriginSessionFixTests(unittest.TestCase):
+    def test_accepts_allowed_origin_with_csrf_and_authenticated_user(self) -> None:
+        guard = WebSocketHandshakeGuard(frozenset({"https://app.example.com"}))
+
+        accepted = guard.validate(
+            {
+                "Origin": "https://APP.example.com",
+                "Sec-WebSocket-Protocol": "csrf-token",
+            },
+            {"csrf_token": "csrf-token", "user_id": "user-123"},
+            session_id_factory=lambda: "fresh-ws-session",
+        )
+
+        self.assertEqual(accepted.origin, "https://app.example.com")
+        self.assertEqual(accepted.user_id, "user-123")
+        self.assertEqual(accepted.session_id, "fresh-ws-session")
+
+    def test_rejects_missing_origin(self) -> None:
+        guard = WebSocketHandshakeGuard(frozenset({"https://app.example.com"}))
+
+        with self.assertRaises(WebSocketSecurityError):
+            guard.validate(
+                {"Sec-WebSocket-Protocol": "csrf-token"},
+                {"csrf_token": "csrf-token", "user_id": "user-123"},
+            )
+
+    def test_rejects_cross_site_origin(self) -> None:
+        guard = WebSocketHandshakeGuard(frozenset({"https://app.example.com"}))
+
+        with self.assertRaises(WebSocketSecurityError):
+            guard.validate(
+                {"Origin": "https://evil.example", "Sec-WebSocket-Protocol": "csrf-token"},
+                {"csrf_token": "csrf-token", "user_id": "user-123"},
+            )
+
+    def test_rejects_plain_http_origin(self) -> None:
+        guard = WebSocketHandshakeGuard(frozenset({"https://app.example.com"}))
+
+        with self.assertRaises(WebSocketSecurityError):
+            guard.validate_origin("http://app.example.com")
+
+    def test_rejects_missing_or_mismatched_csrf(self) -> None:
+        guard = WebSocketHandshakeGuard(frozenset({"https://app.example.com"}))
+
+        with self.assertRaises(WebSocketSecurityError):
+            guard.validate(
+                {"Origin": "https://app.example.com"},
+                {"csrf_token": "csrf-token", "user_id": "user-123"},
+            )
+
+        with self.assertRaises(WebSocketSecurityError):
+            guard.validate(
+                {"Origin": "https://app.example.com", "Sec-WebSocket-Protocol": "wrong"},
+                {"csrf_token": "csrf-token", "user_id": "user-123"},
+            )
+
+    def test_rejects_missing_user(self) -> None:
+        guard = WebSocketHandshakeGuard(frozenset({"https://app.example.com"}))
+
+        with self.assertRaises(WebSocketSecurityError):
+            guard.validate(
+                {"Origin": "https://app.example.com", "Sec-WebSocket-Protocol": "csrf-token"},
+                {"csrf_token": "csrf-token"},
+            )
+
+    def test_generated_session_ids_are_unique_and_high_entropy(self) -> None:
+        tokens = {generate_ws_session_id() for _ in range(200)}
+
+        self.assertEqual(len(tokens), 200)
+        self.assertTrue(all(len(token) >= 32 for token in tokens))
+
+    def test_cookie_headers_use_strict_browser_defaults(self) -> None:
+        headers = websocket_cookie_headers("fresh-ws-session")
+        cookie = headers["Set-Cookie"]
+
+        self.assertIn("ws_session=fresh-ws-session", cookie)
+        self.assertIn("HttpOnly", cookie)
+        self.assertIn("SameSite=Strict", cookie)
+        self.assertIn("Secure", cookie)
+
+    def test_cookie_headers_reject_empty_session_id(self) -> None:
+        with self.assertRaises(WebSocketSecurityError):
+            websocket_cookie_headers("")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #344

## Summary
- adds a framework-neutral WebSocket handshake guard for CSWSH and session prediction defenses
- validates Origin against an explicit HTTPS/WSS allowlist before accepting the socket
- binds the handshake to a CSRF token using constant-time comparison
- requires an authenticated user and issues a fresh high-entropy WebSocket session id
- adds secure WebSocket session cookie defaults
- includes focused unittest coverage for allowed origins, cross-site origins, missing origin/user/CSRF, entropy, and cookie headers

## Verification
- `python -m unittest tests.test_websocket_origin_session_fix -v`
- `python -m py_compile fixes\websocket_origin_session_fix.py tests\test_websocket_origin_session_fix.py`
- `git diff --check`

Payment details are available on request if this is accepted for the listed bounty.
