### PR TITLE
fix: prevent defi withdrawal reentrancy

### DIFF
--- a/fixes/defi_reentrancy_withdraw_fix.py
+++ b/fixes/defi_reentrancy_withdraw_fix.py
@@ -1,0 +1,137 @@
+"""
+Fix for issue #153: Reentrancy Attack on DeFi Withdraw Function.
+
+The vulnerable pattern calls an untrusted transfer hook before updating the
+accounting ledger. A malicious recipient can call withdraw again from that
+hook and drain the same balance multiple times.
+
+This module uses the standard checks-effects-interactions sequence:
+
+1. Validate the withdrawal request.
+2. Enter a reentrancy guard.
+3. Debit the internal balance before the external transfer.
+4. Execute the external transfer.
+5. Roll the debit back if the transfer fails.
+
+The code is framework-neutral Python so the same control flow can be adapted
+to web3.py services, custodial ledgers, or a JavaScript contract wrapper.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+from typing import Callable, Dict
+
+
+Transfer = Callable[[str, Decimal], None]
+
+
+class WithdrawalError(ValueError):
+    """Base class for safe withdrawal failures."""
+
+
+class InvalidAmount(WithdrawalError):
+    """Raised when the requested amount is not a positive numeric value."""
+
+
+class InsufficientFunds(WithdrawalError):
+    """Raised when the account does not have enough balance."""
+
+
+class ReentrancyBlocked(WithdrawalError):
+    """Raised when a withdrawal is attempted from inside another withdrawal."""
+
+
+def normalize_amount(amount: object) -> Decimal:
+    """Return a positive Decimal amount or raise InvalidAmount."""
+    if isinstance(amount, bool):
+        raise InvalidAmount("amount must be numeric, not boolean")
+
+    try:
+        value = Decimal(str(amount))
+    except (InvalidOperation, ValueError) as exc:
+        raise InvalidAmount("amount must be numeric") from exc
+
+    if not value.is_finite() or value <= 0:
+        raise InvalidAmount("amount must be positive and finite")
+
+    return value
+
+
+class SafeWithdrawVault:
+    """Minimal ledger that prevents reentrant withdrawals."""
+
+    def __init__(self) -> None:
+        self._balances: Dict[str, Decimal] = {}
+        self._withdraw_locked = False
+
+    def balance_of(self, account: str) -> Decimal:
+        return self._balances.get(account, Decimal("0"))
+
+    def deposit(self, account: str, amount: object) -> None:
+        value = normalize_amount(amount)
+        self._balances[account] = self.balance_of(account) + value
+
+    def withdraw(self, account: str, amount: object, transfer: Transfer) -> None:
+        """Withdraw funds with checks-effects-interactions ordering.
+
+        The caller supplies ``transfer`` as the only external interaction. In a
+        blockchain service this is the token/native-asset transfer call. In a
+        conventional backend it may be a payment provider dispatch. Because it
+        is untrusted, the internal debit happens before this callback runs and
+        the vault-level guard stays active for the entire interaction.
+        """
+        if not callable(transfer):
+            raise TypeError("transfer must be callable")
+
+        value = normalize_amount(amount)
+
+        if self._withdraw_locked:
+            raise ReentrancyBlocked("reentrant withdraw blocked")
+
+        current_balance = self.balance_of(account)
+        if current_balance < value:
+            raise InsufficientFunds("insufficient balance")
+
+        self._withdraw_locked = True
+        self._balances[account] = current_balance - value
+
+        try:
+            transfer(account, value)
+        except Exception:
+            self._balances[account] = current_balance
+            raise
+        finally:
+            self._withdraw_locked = False
+
+
+class VulnerableWithdrawVault:
+    """Deliberately unsafe reference implementation used for tests."""
+
+    def __init__(self) -> None:
+        self._balances: Dict[str, Decimal] = {}
+
+    def balance_of(self, account: str) -> Decimal:
+        return self._balances.get(account, Decimal("0"))
+
+    def deposit(self, account: str, amount: object) -> None:
+        value = normalize_amount(amount)
+        self._balances[account] = self.balance_of(account) + value
+
+    def withdraw(self, account: str, amount: object, transfer: Transfer) -> None:
+        value = normalize_amount(amount)
+        current_balance = self.balance_of(account)
+        if current_balance < value:
+            raise InsufficientFunds("insufficient balance")
+
+        # Vulnerability: external transfer happens before internal accounting.
+        transfer(account, value)
+        self._balances[account] = current_balance - value
+
+
+if __name__ == "__main__":
+    vault = SafeWithdrawVault()
+    vault.deposit("alice", "100")
+    vault.withdraw("alice", "40", lambda _account, _amount: None)
+    assert vault.balance_of("alice") == Decimal("60")
+    print("defi_reentrancy_withdraw_fix: self-check passed")

--- a/tests/test_defi_reentrancy_withdraw_fix.py
+++ b/tests/test_defi_reentrancy_withdraw_fix.py
@@ -1,0 +1,127 @@
+import unittest
+from decimal import Decimal
+
+from fixes.defi_reentrancy_withdraw_fix import (
+    InsufficientFunds,
+    InvalidAmount,
+    ReentrancyBlocked,
+    SafeWithdrawVault,
+    VulnerableWithdrawVault,
+)
+
+
+class SafeWithdrawVaultTests(unittest.TestCase):
+    def test_vulnerable_pattern_allows_double_transfer(self) -> None:
+        vault = VulnerableWithdrawVault()
+        vault.deposit("attacker", "100")
+        transfers = []
+        reentered = False
+
+        def malicious_transfer(account: str, amount: Decimal) -> None:
+            nonlocal reentered
+            transfers.append((account, amount))
+            if not reentered:
+                reentered = True
+                vault.withdraw("attacker", "100", malicious_transfer)
+
+        vault.withdraw("attacker", "100", malicious_transfer)
+
+        self.assertEqual(transfers, [
+            ("attacker", Decimal("100")),
+            ("attacker", Decimal("100")),
+        ])
+        self.assertEqual(vault.balance_of("attacker"), Decimal("0"))
+
+    def test_safe_vault_blocks_reentrant_withdraw(self) -> None:
+        vault = SafeWithdrawVault()
+        vault.deposit("attacker", "100")
+        transfers = []
+        blocked = []
+
+        def malicious_transfer(account: str, amount: Decimal) -> None:
+            transfers.append((account, amount))
+            try:
+                vault.withdraw("attacker", "100", malicious_transfer)
+            except ReentrancyBlocked as exc:
+                blocked.append(str(exc))
+
+        vault.withdraw("attacker", "100", malicious_transfer)
+
+        self.assertEqual(transfers, [("attacker", Decimal("100"))])
+        self.assertEqual(blocked, ["reentrant withdraw blocked"])
+        self.assertEqual(vault.balance_of("attacker"), Decimal("0"))
+
+    def test_balance_is_debited_before_external_transfer(self) -> None:
+        vault = SafeWithdrawVault()
+        vault.deposit("alice", "100")
+        observed_balance = []
+
+        def transfer(account: str, _amount: Decimal) -> None:
+            observed_balance.append(vault.balance_of(account))
+
+        vault.withdraw("alice", "30", transfer)
+
+        self.assertEqual(observed_balance, [Decimal("70")])
+        self.assertEqual(vault.balance_of("alice"), Decimal("70"))
+
+    def test_failed_transfer_rolls_back_balance_and_releases_lock(self) -> None:
+        vault = SafeWithdrawVault()
+        vault.deposit("alice", "100")
+
+        def failing_transfer(_account: str, _amount: Decimal) -> None:
+            raise RuntimeError("payment provider failed")
+
+        with self.assertRaises(RuntimeError):
+            vault.withdraw("alice", "50", failing_transfer)
+
+        self.assertEqual(vault.balance_of("alice"), Decimal("100"))
+        vault.withdraw("alice", "25", lambda _account, _amount: None)
+        self.assertEqual(vault.balance_of("alice"), Decimal("75"))
+
+    def test_cross_account_reentrancy_is_blocked(self) -> None:
+        vault = SafeWithdrawVault()
+        vault.deposit("attacker", "100")
+        vault.deposit("victim", "100")
+        blocked = []
+
+        def malicious_transfer(_account: str, _amount: Decimal) -> None:
+            try:
+                vault.withdraw("victim", "100", lambda _a, _m: None)
+            except ReentrancyBlocked as exc:
+                blocked.append(str(exc))
+
+        vault.withdraw("attacker", "100", malicious_transfer)
+
+        self.assertEqual(blocked, ["reentrant withdraw blocked"])
+        self.assertEqual(vault.balance_of("attacker"), Decimal("0"))
+        self.assertEqual(vault.balance_of("victim"), Decimal("100"))
+
+    def test_rejects_invalid_amounts(self) -> None:
+        vault = SafeWithdrawVault()
+
+        for bad in ("0", "-1", "NaN", "Infinity", True, "not-a-number"):
+            with self.subTest(amount=bad):
+                with self.assertRaises(InvalidAmount):
+                    vault.deposit("alice", bad)
+
+    def test_rejects_insufficient_funds_without_mutation(self) -> None:
+        vault = SafeWithdrawVault()
+        vault.deposit("alice", "10")
+
+        with self.assertRaises(InsufficientFunds):
+            vault.withdraw("alice", "11", lambda _account, _amount: None)
+
+        self.assertEqual(vault.balance_of("alice"), Decimal("10"))
+
+    def test_transfer_must_be_callable(self) -> None:
+        vault = SafeWithdrawVault()
+        vault.deposit("alice", "10")
+
+        with self.assertRaises(TypeError):
+            vault.withdraw("alice", "1", None)  # type: ignore[arg-type]
+
+        self.assertEqual(vault.balance_of("alice"), Decimal("10"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #153

## Summary
- Add `SafeWithdrawVault` with checks-effects-interactions ordering for DeFi-style withdrawals.
- Add a vault-level reentrancy guard so callback-driven nested withdrawals cannot drain the ledger.
- Normalize positive `Decimal` amounts, reject invalid/insufficient withdrawals, and roll the debit back if the external transfer fails.
- Add regression coverage that demonstrates the vulnerable pattern allows two transfers and the safe path blocks same-account and cross-account reentry.

## Verification
- `python -m unittest tests.test_defi_reentrancy_withdraw_fix -v`
- `python -m py_compile fixes\defi_reentrancy_withdraw_fix.py tests\test_defi_reentrancy_withdraw_fix.py`
- `python fixes\defi_reentrancy_withdraw_fix.py`
- `git diff --check`
