### PR TITLE
fix: pin ssrf targets after dns validation

### DIFF
--- a/fixes/ssrf_dns_rebinding_fix.py
+++ b/fixes/ssrf_dns_rebinding_fix.py
@@ -1,0 +1,186 @@
+"""
+Fix for issue #202: SSRF via DNS rebinding bypassing an allowlist.
+
+The vulnerable pattern validates a URL's hostname, then lets the HTTP client
+resolve that hostname later. An attacker-controlled DNS name can answer with a
+public IP during validation and rebind to 127.0.0.1, 169.254.169.254, or an RFC
+1918 address when the real request is made.
+
+This module prepares a request by resolving the hostname once, rejecting any
+non-public result, and returning an IP-pinned connect URL plus the original
+Host header/SNI name. Callers should connect to ``connect_url`` and preserve
+``host_header``/``server_hostname`` rather than giving the user-supplied host
+back to the HTTP client for another DNS lookup.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from dataclasses import dataclass
+from typing import Callable, Iterable
+from urllib.parse import SplitResult, urlsplit, urlunsplit
+
+
+Resolver = Callable[[str, int | None], Iterable[str]]
+
+
+class SSRFBlocked(ValueError):
+    """Raised when a URL could reach a private or unsafe network target."""
+
+
+class InvalidTargetURL(ValueError):
+    """Raised when a URL is malformed or uses an unsupported scheme."""
+
+
+@dataclass(frozen=True)
+class SafeRequestTarget:
+    """A DNS-rebinding-safe request target."""
+
+    original_url: str
+    connect_url: str
+    host_header: str
+    server_hostname: str
+    vetted_ip: str
+    scheme: str
+    port: int
+
+
+def default_resolver(hostname: str, port: int | None) -> tuple[str, ...]:
+    """Resolve a host to unique textual IP addresses."""
+    infos = socket.getaddrinfo(hostname, port or 0, type=socket.SOCK_STREAM)
+    seen: list[str] = []
+    for info in infos:
+        address = info[4][0]
+        if address not in seen:
+            seen.append(address)
+    return tuple(seen)
+
+
+def is_public_ip(address: str) -> bool:
+    """Return True only for globally routable unicast addresses."""
+    try:
+        ip = ipaddress.ip_address(address)
+    except ValueError as exc:
+        raise SSRFBlocked(f"resolver returned invalid address {address!r}") from exc
+
+    return bool(
+        ip.is_global
+        and not ip.is_private
+        and not ip.is_loopback
+        and not ip.is_link_local
+        and not ip.is_multicast
+        and not ip.is_reserved
+        and not ip.is_unspecified
+    )
+
+
+def _default_port(scheme: str) -> int:
+    if scheme == "https":
+        return 443
+    if scheme == "http":
+        return 80
+    raise InvalidTargetURL("only http and https URLs are allowed")
+
+
+def _parse_target(url: str) -> tuple[SplitResult, str, int]:
+    parsed = urlsplit(url)
+    scheme = parsed.scheme.lower()
+    if scheme not in {"http", "https"}:
+        raise InvalidTargetURL("only http and https URLs are allowed")
+    if not parsed.hostname:
+        raise InvalidTargetURL("target URL must include a hostname")
+    if parsed.username or parsed.password:
+        raise InvalidTargetURL("userinfo in target URLs is not allowed")
+    if any(ord(ch) < 32 for ch in parsed.hostname):
+        raise InvalidTargetURL("hostname contains control characters")
+
+    try:
+        port = parsed.port or _default_port(scheme)
+    except ValueError as exc:
+        raise InvalidTargetURL("invalid port") from exc
+
+    if port <= 0 or port > 65535:
+        raise InvalidTargetURL("invalid port")
+
+    return parsed, parsed.hostname.lower().rstrip("."), port
+
+
+def _ip_netloc(address: str, port: int) -> str:
+    ip = ipaddress.ip_address(address)
+    host = f"[{address}]" if ip.version == 6 else address
+    return f"{host}:{port}"
+
+
+def _resolve_or_parse_ip(hostname: str, port: int, resolver: Resolver) -> tuple[str, ...]:
+    try:
+        ipaddress.ip_address(hostname)
+        return (hostname,)
+    except ValueError:
+        pass
+
+    addresses = tuple(resolver(hostname, port))
+    if not addresses:
+        raise SSRFBlocked("hostname did not resolve")
+    return addresses
+
+
+def prepare_safe_request_target(
+    url: str,
+    *,
+    resolver: Resolver = default_resolver,
+) -> SafeRequestTarget:
+    """Validate and pin a URL target against DNS rebinding.
+
+    The function rejects the entire hostname if any returned address is not
+    public. This prevents attackers from hiding a private target behind a mixed
+    response set and waiting for the HTTP client's address selection to choose
+    the unsafe address.
+    """
+    parsed, hostname, port = _parse_target(url)
+    addresses = _resolve_or_parse_ip(hostname, port, resolver)
+
+    unsafe = [address for address in addresses if not is_public_ip(address)]
+    if unsafe:
+        raise SSRFBlocked(f"unsafe resolved address(es): {', '.join(unsafe)}")
+
+    vetted_ip = addresses[0]
+    connect_url = urlunsplit(
+        (
+            parsed.scheme.lower(),
+            _ip_netloc(vetted_ip, port),
+            parsed.path or "/",
+            parsed.query,
+            "",
+        )
+    )
+
+    host_header = hostname if parsed.port is None else f"{hostname}:{port}"
+    return SafeRequestTarget(
+        original_url=url,
+        connect_url=connect_url,
+        host_header=host_header,
+        server_hostname=hostname,
+        vetted_ip=vetted_ip,
+        scheme=parsed.scheme.lower(),
+        port=port,
+    )
+
+
+def validate_redirect_chain(
+    urls: Iterable[str],
+    *,
+    resolver: Resolver = default_resolver,
+) -> tuple[SafeRequestTarget, ...]:
+    """Validate every hop before following redirects."""
+    return tuple(prepare_safe_request_target(url, resolver=resolver) for url in urls)
+
+
+if __name__ == "__main__":
+    target = prepare_safe_request_target(
+        "https://example.com/api?q=1",
+        resolver=lambda _host, _port: ("93.184.216.34",),
+    )
+    assert target.connect_url == "https://93.184.216.34:443/api?q=1"
+    assert target.host_header == "example.com"
+    print("ssrf_dns_rebinding_fix: self-check passed")

--- a/tests/test_ssrf_dns_rebinding_fix.py
+++ b/tests/test_ssrf_dns_rebinding_fix.py
@@ -1,0 +1,131 @@
+import unittest
+
+from fixes.ssrf_dns_rebinding_fix import (
+    InvalidTargetURL,
+    SSRFBlocked,
+    is_public_ip,
+    prepare_safe_request_target,
+    validate_redirect_chain,
+)
+
+
+PUBLIC_V4 = "93.184.216.34"
+PUBLIC_V6 = "2606:2800:220:1:248:1893:25c8:1946"
+
+
+class SSRFDNSRebindingFixTests(unittest.TestCase):
+    def test_prepares_ip_pinned_request_with_original_host_header(self) -> None:
+        target = prepare_safe_request_target(
+            "https://api.example.com/v1/memory?limit=10",
+            resolver=lambda host, port: (PUBLIC_V4,),
+        )
+
+        self.assertEqual(target.connect_url, "https://93.184.216.34:443/v1/memory?limit=10")
+        self.assertEqual(target.host_header, "api.example.com")
+        self.assertEqual(target.server_hostname, "api.example.com")
+        self.assertEqual(target.vetted_ip, PUBLIC_V4)
+        self.assertEqual(target.port, 443)
+
+    def test_custom_port_is_preserved_in_connect_url_and_host_header(self) -> None:
+        target = prepare_safe_request_target(
+            "http://api.example.com:8080/status",
+            resolver=lambda _host, _port: (PUBLIC_V4,),
+        )
+
+        self.assertEqual(target.connect_url, "http://93.184.216.34:8080/status")
+        self.assertEqual(target.host_header, "api.example.com:8080")
+        self.assertEqual(target.port, 8080)
+
+    def test_rejects_direct_private_loopback_and_metadata_addresses(self) -> None:
+        for url in (
+            "http://127.0.0.1/admin",
+            "http://10.0.0.4/admin",
+            "http://172.16.0.10/admin",
+            "http://192.168.1.20/admin",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://[::1]/admin",
+        ):
+            with self.subTest(url=url):
+                with self.assertRaises(SSRFBlocked):
+                    prepare_safe_request_target(url)
+
+    def test_rejects_hostname_that_resolves_to_private_address(self) -> None:
+        with self.assertRaises(SSRFBlocked):
+            prepare_safe_request_target(
+                "https://attacker.example/fetch",
+                resolver=lambda _host, _port: ("127.0.0.1",),
+            )
+
+    def test_rejects_mixed_public_private_resolution_set(self) -> None:
+        with self.assertRaises(SSRFBlocked):
+            prepare_safe_request_target(
+                "https://rebind.example/fetch",
+                resolver=lambda _host, _port: (PUBLIC_V4, "169.254.169.254"),
+            )
+
+    def test_resolver_is_called_once_and_client_receives_ip_target(self) -> None:
+        calls = []
+
+        def rebinding_resolver(host: str, port: int | None):
+            calls.append((host, port))
+            return (PUBLIC_V4,)
+
+        target = prepare_safe_request_target(
+            "https://rebind.example/data",
+            resolver=rebinding_resolver,
+        )
+
+        self.assertEqual(calls, [("rebind.example", 443)])
+        self.assertNotIn("rebind.example", target.connect_url)
+        self.assertEqual(target.host_header, "rebind.example")
+
+    def test_redirect_chain_revalidates_every_hop(self) -> None:
+        def resolver(host: str, _port: int | None):
+            if host == "safe.example":
+                return (PUBLIC_V4,)
+            if host == "internal.example":
+                return ("10.0.0.5",)
+            raise AssertionError(host)
+
+        with self.assertRaises(SSRFBlocked):
+            validate_redirect_chain(
+                [
+                    "https://safe.example/start",
+                    "https://internal.example/admin",
+                ],
+                resolver=resolver,
+            )
+
+    def test_supports_public_ipv6_connect_url_brackets(self) -> None:
+        target = prepare_safe_request_target(
+            "https://ipv6.example/path",
+            resolver=lambda _host, _port: (PUBLIC_V6,),
+        )
+
+        self.assertEqual(
+            target.connect_url,
+            "https://[2606:2800:220:1:248:1893:25c8:1946]:443/path",
+        )
+        self.assertEqual(target.vetted_ip, PUBLIC_V6)
+
+    def test_rejects_invalid_url_shapes(self) -> None:
+        for url in (
+            "file:///etc/passwd",
+            "gopher://example.com/_payload",
+            "https://user:pass@example.com/private",
+            "https:///missing-host",
+            "http://example.com:99999/",
+        ):
+            with self.subTest(url=url):
+                with self.assertRaises(InvalidTargetURL):
+                    prepare_safe_request_target(url, resolver=lambda _h, _p: (PUBLIC_V4,))
+
+    def test_public_ip_classifier_blocks_reserved_and_private_ranges(self) -> None:
+        self.assertTrue(is_public_ip(PUBLIC_V4))
+        for address in ("0.0.0.0", "127.0.0.1", "10.1.2.3", "192.168.1.1", "224.0.0.1"):
+            with self.subTest(address=address):
+                self.assertFalse(is_public_ip(address))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #202

## Summary
- Add a dependency-free SSRF/DNS-rebinding guard for outbound URL fetches.
- Resolve the hostname once, reject direct/mixed/private/link-local/loopback/metadata IPs, and return an IP-pinned connect URL with the original Host header/SNI name.
- Revalidate every redirect hop before following it.
- Cover direct private IPs, DNS names resolving to private IPs, mixed public/private answer sets, unsupported schemes, userinfo, custom ports, IPv6 bracket formatting, and redirect-to-private rebinding.

## Verification
- `python -m unittest tests.test_ssrf_dns_rebinding_fix -v`
- `python -m py_compile fixes\ssrf_dns_rebinding_fix.py tests\test_ssrf_dns_rebinding_fix.py`
- `python fixes\ssrf_dns_rebinding_fix.py`
- `git diff --check`
