### PR TITLE
fix: prevent distributed double spending

### DIFF
--- a/fixes/distributed_double_spend_fix.py
+++ b/fixes/distributed_double_spend_fix.py
@@ -1,0 +1,243 @@
+"""Fix for issue #200: distributed transaction race double spending.
+
+The vulnerable pattern is a read-check-write balance update performed without
+an account-level lock or idempotency record. Two concurrent requests can both
+observe the same source balance, both decide the transfer is affordable, then
+write back from the stale snapshot. That lets the source spend the same funds
+twice while only one debit is visible.
+
+This module provides a small dependency-free ledger guard that can be adapted
+to a database transaction, wallet service, or message-driven payment worker:
+
+* acquire per-account locks in stable order to prevent race windows and
+  deadlocks;
+* require a caller-supplied idempotency key for every transfer;
+* reject conflicting reuse of an idempotency key;
+* optionally enforce optimistic source/destination versions;
+* debit and credit in one critical section.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from decimal import Decimal
+from threading import Lock
+from time import sleep
+from typing import Iterator, MutableMapping
+
+
+class DoubleSpendGuardError(ValueError):
+    """Raised when a transfer would break double-spend protections."""
+
+
+@dataclass
+class Account:
+    """Minimal account record with integer minor-unit balance and version."""
+
+    account_id: str
+    balance: int
+    version: int = 0
+
+
+@dataclass(frozen=True)
+class TransferResult:
+    """Stable result returned for a successful idempotent transfer."""
+
+    idempotency_key: str
+    source_id: str
+    destination_id: str
+    amount: int
+    source_balance: int
+    destination_balance: int
+    source_version: int
+    destination_version: int
+
+
+@dataclass
+class _IdempotencyEntry:
+    fingerprint: tuple[str, str, int]
+    result: TransferResult | None = None
+
+
+class DistributedLedger:
+    """Thread-safe transfer guard for distributed wallet/account services."""
+
+    def __init__(self, accounts: MutableMapping[str, Account]):
+        self.accounts = accounts
+        self._global_lock = Lock()
+        self._idempotency_lock = Lock()
+        self._account_locks: dict[str, Lock] = {}
+        self._idempotency: dict[str, _IdempotencyEntry] = {}
+
+    def transfer(
+        self,
+        *,
+        idempotency_key: str,
+        source_id: str,
+        destination_id: str,
+        amount: int | Decimal,
+        expected_source_version: int | None = None,
+        expected_destination_version: int | None = None,
+    ) -> TransferResult:
+        """Move funds exactly once for a unique idempotency key.
+
+        Repeating the same request after success returns the original result
+        without another debit. Reusing the key for a different transfer is
+        rejected because that would let clients overwrite audit history.
+        """
+
+        cents = _normalize_minor_units(amount)
+        if source_id == destination_id:
+            raise DoubleSpendGuardError("source and destination must differ")
+
+        fingerprint = (source_id, destination_id, cents)
+        entry = self._reserve_idempotency_key(idempotency_key, fingerprint)
+        if entry.result is not None:
+            return entry.result
+
+        try:
+            with self._locked_accounts(source_id, destination_id):
+                source = self._get_account(source_id)
+                destination = self._get_account(destination_id)
+
+                if (
+                    expected_source_version is not None
+                    and source.version != expected_source_version
+                ):
+                    raise DoubleSpendGuardError("stale source account version")
+                if (
+                    expected_destination_version is not None
+                    and destination.version != expected_destination_version
+                ):
+                    raise DoubleSpendGuardError("stale destination account version")
+                if source.balance < cents:
+                    raise DoubleSpendGuardError("insufficient funds")
+
+                source.balance -= cents
+                destination.balance += cents
+                source.version += 1
+                destination.version += 1
+
+                result = TransferResult(
+                    idempotency_key=idempotency_key,
+                    source_id=source_id,
+                    destination_id=destination_id,
+                    amount=cents,
+                    source_balance=source.balance,
+                    destination_balance=destination.balance,
+                    source_version=source.version,
+                    destination_version=destination.version,
+                )
+
+            with self._idempotency_lock:
+                self._idempotency[idempotency_key].result = result
+            return result
+        except Exception:
+            with self._idempotency_lock:
+                current = self._idempotency.get(idempotency_key)
+                if current is entry and current.result is None:
+                    del self._idempotency[idempotency_key]
+            raise
+
+    def _reserve_idempotency_key(
+        self, idempotency_key: str, fingerprint: tuple[str, str, int]
+    ) -> _IdempotencyEntry:
+        clean_key = idempotency_key.strip()
+        if not clean_key:
+            raise DoubleSpendGuardError("idempotency key is required")
+
+        with self._idempotency_lock:
+            existing = self._idempotency.get(clean_key)
+            if existing is not None:
+                if existing.fingerprint != fingerprint:
+                    raise DoubleSpendGuardError("idempotency key reused with different transfer")
+                if existing.result is None:
+                    raise DoubleSpendGuardError("idempotent transfer already in progress")
+                return existing
+
+            entry = _IdempotencyEntry(fingerprint=fingerprint)
+            self._idempotency[clean_key] = entry
+            return entry
+
+    @contextmanager
+    def _locked_accounts(self, source_id: str, destination_id: str) -> Iterator[None]:
+        account_ids = sorted({source_id, destination_id})
+        locks = [self._lock_for(account_id) for account_id in account_ids]
+        for lock in locks:
+            lock.acquire()
+        try:
+            yield
+        finally:
+            for lock in reversed(locks):
+                lock.release()
+
+    def _lock_for(self, account_id: str) -> Lock:
+        with self._global_lock:
+            return self._account_locks.setdefault(account_id, Lock())
+
+    def _get_account(self, account_id: str) -> Account:
+        try:
+            return self.accounts[account_id]
+        except KeyError as exc:
+            raise DoubleSpendGuardError(f"unknown account: {account_id}") from exc
+
+
+def vulnerable_transfer_without_lock(
+    accounts: MutableMapping[str, Account],
+    *,
+    source_id: str,
+    destination_id: str,
+    amount: int,
+    race_barrier=None,
+    write_delay_seconds: float = 0.001,
+) -> bool:
+    """Demonstrate the stale-snapshot bug the guard prevents."""
+
+    source_snapshot = accounts[source_id].balance
+    destination_snapshot = accounts[destination_id].balance
+
+    if race_barrier is not None:
+        race_barrier.wait()
+
+    if source_snapshot < amount:
+        return False
+
+    sleep(write_delay_seconds)
+    accounts[source_id].balance = source_snapshot - amount
+    accounts[destination_id].balance = destination_snapshot + amount
+    return True
+
+
+def _normalize_minor_units(amount: int | Decimal) -> int:
+    if isinstance(amount, bool):
+        raise DoubleSpendGuardError("amount must be an integer minor-unit value")
+    if isinstance(amount, Decimal):
+        if amount != amount.to_integral_value():
+            raise DoubleSpendGuardError("amount must not contain fractional minor units")
+        amount = int(amount)
+    if not isinstance(amount, int):
+        raise DoubleSpendGuardError("amount must be an integer minor-unit value")
+    if amount <= 0:
+        raise DoubleSpendGuardError("amount must be positive")
+    return amount
+
+
+def _demo() -> None:
+    accounts = {
+        "alice": Account("alice", 100),
+        "bob": Account("bob", 0),
+    }
+    ledger = DistributedLedger(accounts)
+    result = ledger.transfer(
+        idempotency_key="demo-1",
+        source_id="alice",
+        destination_id="bob",
+        amount=25,
+        expected_source_version=0,
+    )
+    print(result)
+
+
+if __name__ == "__main__":
+    _demo()

--- a/tests/test_distributed_double_spend_fix.py
+++ b/tests/test_distributed_double_spend_fix.py
@@ -1,0 +1,197 @@
+"""Regression tests for issue #200 distributed transaction double spending."""
+
+from __future__ import annotations
+
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from decimal import Decimal
+from threading import Barrier
+
+from fixes.distributed_double_spend_fix import (
+    Account,
+    DistributedLedger,
+    DoubleSpendGuardError,
+    vulnerable_transfer_without_lock,
+)
+
+
+class DistributedDoubleSpendFixTests(unittest.TestCase):
+    def test_vulnerable_snapshot_flow_double_spends_under_race(self) -> None:
+        accounts = {
+            "alice": Account("alice", 100),
+            "bob": Account("bob", 0),
+            "carol": Account("carol", 0),
+        }
+        barrier = Barrier(2)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(
+                vulnerable_transfer_without_lock,
+                accounts,
+                source_id="alice",
+                destination_id="bob",
+                amount=60,
+                race_barrier=barrier,
+            )
+            second = pool.submit(
+                vulnerable_transfer_without_lock,
+                accounts,
+                source_id="alice",
+                destination_id="carol",
+                amount=60,
+                race_barrier=barrier,
+            )
+
+        self.assertTrue(first.result())
+        self.assertTrue(second.result())
+        self.assertEqual(accounts["alice"].balance, 40)
+        self.assertEqual(accounts["bob"].balance + accounts["carol"].balance, 120)
+
+    def test_guarded_ledger_allows_only_one_concurrent_spend(self) -> None:
+        accounts = {
+            "alice": Account("alice", 100),
+            "bob": Account("bob", 0),
+            "carol": Account("carol", 0),
+        }
+        ledger = DistributedLedger(accounts)
+        barrier = Barrier(2)
+
+        def spend(destination: str, key: str):
+            barrier.wait()
+            return ledger.transfer(
+                idempotency_key=key,
+                source_id="alice",
+                destination_id=destination,
+                amount=60,
+            )
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [
+                pool.submit(spend, "bob", "spend-bob"),
+                pool.submit(spend, "carol", "spend-carol"),
+            ]
+
+        successes = []
+        failures = []
+        for future in futures:
+            try:
+                successes.append(future.result())
+            except DoubleSpendGuardError as exc:
+                failures.append(str(exc))
+
+        self.assertEqual(len(successes), 1)
+        self.assertEqual(failures, ["insufficient funds"])
+        self.assertEqual(accounts["alice"].balance, 40)
+        self.assertEqual(accounts["bob"].balance + accounts["carol"].balance, 60)
+        self.assertEqual(sum(account.balance for account in accounts.values()), 100)
+
+    def test_idempotent_retry_returns_original_result_without_second_debit(self) -> None:
+        accounts = {
+            "alice": Account("alice", 100),
+            "bob": Account("bob", 0),
+        }
+        ledger = DistributedLedger(accounts)
+
+        first = ledger.transfer(
+            idempotency_key="txn-1",
+            source_id="alice",
+            destination_id="bob",
+            amount=25,
+            expected_source_version=0,
+        )
+        second = ledger.transfer(
+            idempotency_key="txn-1",
+            source_id="alice",
+            destination_id="bob",
+            amount=25,
+            expected_source_version=0,
+        )
+
+        self.assertEqual(first, second)
+        self.assertEqual(accounts["alice"].balance, 75)
+        self.assertEqual(accounts["bob"].balance, 25)
+        self.assertEqual(accounts["alice"].version, 1)
+
+    def test_conflicting_idempotency_key_reuse_is_rejected(self) -> None:
+        accounts = {
+            "alice": Account("alice", 100),
+            "bob": Account("bob", 0),
+            "carol": Account("carol", 0),
+        }
+        ledger = DistributedLedger(accounts)
+        ledger.transfer(
+            idempotency_key="txn-conflict",
+            source_id="alice",
+            destination_id="bob",
+            amount=10,
+        )
+
+        with self.assertRaisesRegex(DoubleSpendGuardError, "reused"):
+            ledger.transfer(
+                idempotency_key="txn-conflict",
+                source_id="alice",
+                destination_id="carol",
+                amount=10,
+            )
+
+    def test_stale_version_is_rejected_before_debit(self) -> None:
+        accounts = {
+            "alice": Account("alice", 100, version=3),
+            "bob": Account("bob", 0),
+        }
+        ledger = DistributedLedger(accounts)
+
+        with self.assertRaisesRegex(DoubleSpendGuardError, "stale source"):
+            ledger.transfer(
+                idempotency_key="txn-stale",
+                source_id="alice",
+                destination_id="bob",
+                amount=10,
+                expected_source_version=2,
+            )
+
+        self.assertEqual(accounts["alice"].balance, 100)
+        self.assertEqual(accounts["bob"].balance, 0)
+
+    def test_opposing_transfers_do_not_deadlock(self) -> None:
+        accounts = {
+            "alice": Account("alice", 100),
+            "bob": Account("bob", 100),
+        }
+        ledger = DistributedLedger(accounts)
+        barrier = Barrier(2)
+
+        def transfer(source: str, destination: str, key: str):
+            barrier.wait()
+            return ledger.transfer(
+                idempotency_key=key,
+                source_id=source,
+                destination_id=destination,
+                amount=20,
+            )
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(transfer, "alice", "bob", "a-to-b")
+            second = pool.submit(transfer, "bob", "alice", "b-to-a")
+
+        self.assertEqual(first.result().amount, 20)
+        self.assertEqual(second.result().amount, 20)
+        self.assertEqual(accounts["alice"].balance, 100)
+        self.assertEqual(accounts["bob"].balance, 100)
+
+    def test_invalid_amounts_are_rejected(self) -> None:
+        ledger = DistributedLedger({"alice": Account("alice", 100), "bob": Account("bob", 0)})
+
+        for amount in (0, -1, True, "10", Decimal("1.5")):
+            with self.subTest(amount=amount):
+                with self.assertRaises(DoubleSpendGuardError):
+                    ledger.transfer(
+                        idempotency_key=f"bad-{amount}",
+                        source_id="alice",
+                        destination_id="bob",
+                        amount=amount,  # type: ignore[arg-type]
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #200.

## Summary

- Add a dependency-free distributed ledger guard for race-condition double-spend prevention.
- Serialize source/destination account mutations with stable per-account lock ordering.
- Require idempotency keys, reject conflicting key reuse, and return the original result on safe retries.
- Support optimistic account version checks and minor-unit amount validation.
- Include a vulnerable concurrent read-check-write helper used only by tests to prove the race.

## Verification

```text
python -m unittest tests.test_distributed_double_spend_fix -v
python -m py_compile fixes\distributed_double_spend_fix.py tests\test_distributed_double_spend_fix.py
python fixes\distributed_double_spend_fix.py
git diff --check
```

All commands pass locally.

Payment details are available on request after review/acceptance.
