### PR TITLE
fix: prevent prototype pollution dom xss

### DIFF
--- a/fixes/prototype_pollution_dom_xss_fix.js
+++ b/fixes/prototype_pollution_dom_xss_fix.js
@@ -1,0 +1,151 @@
+"use strict";
+
+/**
+ * Fix for Issue #198: Prototype Pollution -> DOM XSS -> Account Takeover.
+ *
+ * The vulnerable chain usually starts with an unsafe deep merge:
+ *
+ *   Object.assign(config, JSON.parse(body))
+ *   merge(defaults, req.body)
+ *
+ * A payload containing __proto__, constructor.prototype, or prototype can add
+ * attacker-controlled inherited properties.  Frontend code that later trusts
+ * polluted flags or writes polluted strings with innerHTML can turn that into
+ * DOM XSS and account-changing requests.
+ *
+ * This module keeps untrusted data on null-prototype objects, rejects
+ * prototype-polluting keys at every depth, rejects accessors so getters cannot
+ * run during sanitization, renders attacker-controlled text with textContent,
+ * and escapes JSON embedded into HTML script blocks.
+ */
+
+const POLLUTION_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+const SAFE_ACCOUNT_FIELDS = new Set(["displayName", "email", "marketingOptIn"]);
+const MAX_KEY_LENGTH = 128;
+const MAX_STRING_LENGTH = 10_000;
+
+class PollutionError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PollutionError";
+  }
+}
+
+function isPlainObject(value) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function assertSafeKey(key) {
+  if (typeof key !== "string" || key.length === 0 || key.length > MAX_KEY_LENGTH) {
+    throw new PollutionError("invalid object key");
+  }
+  if (POLLUTION_KEYS.has(key) || key.startsWith("__") || /[\x00-\x1f\x7f]/u.test(key)) {
+    throw new PollutionError(`unsafe object key: ${key}`);
+  }
+}
+
+function cloneSafeValue(value) {
+  if (value === null || typeof value === "boolean" || typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "string") {
+    if (value.length > MAX_STRING_LENGTH) {
+      throw new PollutionError("string value too large");
+    }
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => cloneSafeValue(item));
+  }
+  if (isPlainObject(value)) {
+    return sanitizeObjectGraph(value);
+  }
+  throw new PollutionError("unsupported untrusted value type");
+}
+
+function sanitizeObjectGraph(input) {
+  if (!isPlainObject(input)) {
+    throw new PollutionError("expected a plain object");
+  }
+
+  const output = Object.create(null);
+  const descriptors = Object.getOwnPropertyDescriptors(input);
+
+  for (const [key, descriptor] of Object.entries(descriptors)) {
+    assertSafeKey(key);
+    if ("get" in descriptor || "set" in descriptor) {
+      throw new PollutionError(`accessor properties are not allowed: ${key}`);
+    }
+    output[key] = cloneSafeValue(descriptor.value);
+  }
+
+  return output;
+}
+
+function safeDeepMerge(base, patch) {
+  const left = base === undefined ? Object.create(null) : sanitizeObjectGraph(base);
+  const right = sanitizeObjectGraph(patch);
+
+  for (const [key, value] of Object.entries(right)) {
+    if (isPlainObject(left[key]) && isPlainObject(value)) {
+      left[key] = safeDeepMerge(left[key], value);
+    } else {
+      left[key] = cloneSafeValue(value);
+    }
+  }
+
+  return left;
+}
+
+function safeSetTextContent(element, value) {
+  if (!element || typeof element !== "object" || !("textContent" in element)) {
+    throw new TypeError("element with textContent is required");
+  }
+  element.textContent = value == null ? "" : String(value);
+  if ("innerHTML" in element) {
+    element.innerHTML = "";
+  }
+  return element;
+}
+
+function escapeJsonForHtmlScript(value) {
+  const safeValue = cloneSafeValue(value);
+  return JSON.stringify(safeValue)
+    .replace(/</gu, "\\u003c")
+    .replace(/>/gu, "\\u003e")
+    .replace(/&/gu, "\\u0026")
+    .replace(/\u2028/gu, "\\u2028")
+    .replace(/\u2029/gu, "\\u2029");
+}
+
+function createAccountUpdatePayload(input, csrfToken) {
+  if (typeof csrfToken !== "string" || csrfToken.length < 16) {
+    throw new PollutionError("valid server-issued CSRF token is required");
+  }
+
+  const clean = sanitizeObjectGraph(input);
+  const payload = Object.create(null);
+
+  for (const [key, value] of Object.entries(clean)) {
+    if (SAFE_ACCOUNT_FIELDS.has(key)) {
+      payload[key] = cloneSafeValue(value);
+    }
+  }
+
+  payload.csrfToken = csrfToken;
+  return payload;
+}
+
+module.exports = {
+  PollutionError,
+  POLLUTION_KEYS,
+  createAccountUpdatePayload,
+  escapeJsonForHtmlScript,
+  safeDeepMerge,
+  safeSetTextContent,
+  sanitizeObjectGraph,
+};

--- a/tests/test_prototype_pollution_dom_xss_fix.js
+++ b/tests/test_prototype_pollution_dom_xss_fix.js
@@ -1,0 +1,111 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  PollutionError,
+  createAccountUpdatePayload,
+  escapeJsonForHtmlScript,
+  safeDeepMerge,
+  safeSetTextContent,
+  sanitizeObjectGraph,
+} = require("../fixes/prototype_pollution_dom_xss_fix");
+
+test("rejects direct __proto__ pollution without mutating Object.prototype", () => {
+  const payload = JSON.parse('{"__proto__":{"isAdmin":true}}');
+
+  assert.throws(() => sanitizeObjectGraph(payload), PollutionError);
+  assert.equal({}.isAdmin, undefined);
+});
+
+test("rejects nested constructor/prototype pollution payloads", () => {
+  const payload = {
+    preferences: {
+      constructor: {
+        prototype: {
+          xssSink: "<img src=x onerror=alert(1)>",
+        },
+      },
+    },
+  };
+
+  assert.throws(() => safeDeepMerge({ preferences: { theme: "light" } }, payload), PollutionError);
+  assert.equal({}.xssSink, undefined);
+});
+
+test("clones normal data onto null-prototype objects", () => {
+  const merged = safeDeepMerge(
+    { profile: { theme: "light" } },
+    { profile: { language: "en" }, flags: ["beta"] },
+  );
+
+  assert.equal(Object.getPrototypeOf(merged), null);
+  assert.equal(Object.getPrototypeOf(merged.profile), null);
+  assert.deepEqual(Object.fromEntries(Object.entries(merged.profile)), { theme: "light", language: "en" });
+  assert.deepEqual(merged.flags, ["beta"]);
+});
+
+test("rejects accessors before attacker getters can execute", () => {
+  let getterRan = false;
+  const payload = {};
+  Object.defineProperty(payload, "displayName", {
+    enumerable: true,
+    get() {
+      getterRan = true;
+      return "<img src=x onerror=alert(1)>";
+    },
+  });
+
+  assert.throws(() => sanitizeObjectGraph(payload), PollutionError);
+  assert.equal(getterRan, false);
+});
+
+test("renders attacker-controlled labels through textContent, not innerHTML", () => {
+  const element = { textContent: "", innerHTML: "<b>old</b>" };
+
+  safeSetTextContent(element, "<img src=x onerror=alert(1)>");
+
+  assert.equal(element.textContent, "<img src=x onerror=alert(1)>");
+  assert.equal(element.innerHTML, "");
+});
+
+test("escapes frontend JSON so script tags cannot be broken out", () => {
+  const encoded = escapeJsonForHtmlScript({
+    displayName: "</script><script>alert(1)</script>",
+    bio: "A & B",
+  });
+
+  assert(!encoded.includes("</script>"));
+  assert(!encoded.includes("<script>"));
+  assert(encoded.includes("\\u003c/script\\u003e"));
+  assert(encoded.includes("\\u0026"));
+});
+
+test("account update payload ignores inherited admin flags and uses server CSRF", () => {
+  Object.defineProperty(Object.prototype, "isAdmin", {
+    configurable: true,
+    enumerable: true,
+    value: true,
+  });
+
+  try {
+    const input = { displayName: "Ada", marketingOptIn: true };
+    const payload = createAccountUpdatePayload(input, "csrf-token-value-12345");
+
+    assert.equal(Object.getPrototypeOf(payload), null);
+    assert.equal(payload.displayName, "Ada");
+    assert.equal(payload.marketingOptIn, true);
+    assert.equal(payload.csrfToken, "csrf-token-value-12345");
+    assert.equal(Object.hasOwn(payload, "isAdmin"), false);
+    assert.equal(payload.role, undefined);
+  } finally {
+    delete Object.prototype.isAdmin;
+  }
+});
+
+test("account update payload rejects attacker-supplied CSRF replacement keys", () => {
+  const input = JSON.parse('{"displayName":"Ada","__proto__":{"csrfToken":"evil"}}');
+
+  assert.throws(() => createAccountUpdatePayload(input, "csrf-token-value-12345"), PollutionError);
+});


### PR DESCRIPTION
Fixes #198.

## Summary
- Adds a JavaScript guard for the prototype-pollution -> DOM-XSS -> account-takeover chain.
- Rejects `__proto__`, `constructor`, `prototype`, dunder-prefixed keys, control-character keys, accessors, and unsupported untrusted value types at every depth.
- Clones untrusted data onto null-prototype objects, writes attacker-controlled text through `textContent`, escapes JSON embedded in HTML script blocks, and builds account-update payloads with a server-issued CSRF token.

## Verification
- `node --test tests\test_prototype_pollution_dom_xss_fix.js`
- `node --check fixes\prototype_pollution_dom_xss_fix.js`
- `node --check tests\test_prototype_pollution_dom_xss_fix.js`
- `git diff --check`
