### PR TITLE
fix: prevent upload race conditions

### DIFF
--- a/fixes/race_condition_upload_fix.py
+++ b/fixes/race_condition_upload_fix.py
@@ -1,0 +1,140 @@
+"""Race-safe file upload helper for issue #85.
+
+The vulnerable pattern is a check-then-write upload path: two concurrent
+requests can validate the same target and then overwrite or interleave data.
+This module keeps validation and publish under a per-target lock, writes to a
+temporary file in the destination directory, and publishes with an atomic
+replace only after the full payload is verified.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+import threading
+from pathlib import Path
+from typing import Iterable
+
+
+SAFE_FILENAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+class UnsafeUpload(ValueError):
+    """Raised when upload input is unsafe or violates policy."""
+
+
+class UploadConflict(FileExistsError):
+    """Raised when an upload would overwrite an existing file."""
+
+
+class AtomicUploadStore:
+    """Store uploaded bytes without check/write race windows."""
+
+    def __init__(
+        self,
+        upload_dir: str | os.PathLike[str],
+        *,
+        max_bytes: int = 10 * 1024 * 1024,
+        allowed_extensions: Iterable[str] | None = None,
+    ) -> None:
+        self.upload_dir = Path(upload_dir).resolve()
+        self.upload_dir.mkdir(parents=True, exist_ok=True)
+        if max_bytes <= 0:
+            raise ValueError("max_bytes must be positive")
+        self.max_bytes = max_bytes
+        self.allowed_extensions = self._normalize_extensions(allowed_extensions)
+        self._locks: dict[Path, threading.Lock] = {}
+        self._locks_guard = threading.Lock()
+
+    @staticmethod
+    def _normalize_extensions(extensions: Iterable[str] | None) -> frozenset[str] | None:
+        if extensions is None:
+            return None
+        normalized = frozenset(
+            item.lower() if item.startswith(".") else f".{item.lower()}"
+            for item in extensions
+        )
+        if not normalized:
+            raise ValueError("allowed_extensions cannot be empty")
+        return normalized
+
+    def _target_lock(self, path: Path) -> threading.Lock:
+        with self._locks_guard:
+            lock = self._locks.get(path)
+            if lock is None:
+                lock = threading.Lock()
+                self._locks[path] = lock
+            return lock
+
+    def _safe_target(self, filename: str) -> Path:
+        if not isinstance(filename, str):
+            raise UnsafeUpload("filename must be text")
+        if "\x00" in filename or "/" in filename or "\\" in filename:
+            raise UnsafeUpload("filename must not contain path separators")
+        if filename in {"", ".", ".."} or not SAFE_FILENAME_RE.fullmatch(filename):
+            raise UnsafeUpload("filename contains unsupported characters")
+
+        target = (self.upload_dir / filename).resolve()
+        try:
+            target.relative_to(self.upload_dir)
+        except ValueError as exc:
+            raise UnsafeUpload("filename escapes upload directory") from exc
+
+        if self.allowed_extensions is not None and target.suffix.lower() not in self.allowed_extensions:
+            raise UnsafeUpload("file extension is not allowed")
+        return target
+
+    def save(self, filename: str, content: bytes, *, overwrite: bool = False) -> Path:
+        """Validate and atomically save one upload.
+
+        The existence check, temporary write, validation, and final publish are
+        protected by a per-target lock. With ``overwrite=False`` concurrent
+        attempts for the same target produce exactly one winner.
+        """
+
+        if not isinstance(content, bytes):
+            raise UnsafeUpload("content must be bytes")
+        if len(content) == 0:
+            raise UnsafeUpload("empty uploads are not accepted")
+        if len(content) > self.max_bytes:
+            raise UnsafeUpload("upload exceeds maximum size")
+
+        target = self._safe_target(filename)
+        lock = self._target_lock(target)
+        with lock:
+            if target.exists() and not overwrite:
+                raise UploadConflict(f"{target.name} already exists")
+
+            tmp_path = self._write_temp_file(target, content)
+            try:
+                if tmp_path.stat().st_size != len(content):
+                    raise UnsafeUpload("temporary upload size changed during write")
+                if target.exists() and not overwrite:
+                    raise UploadConflict(f"{target.name} already exists")
+                os.replace(tmp_path, target)
+            except Exception:
+                tmp_path.unlink(missing_ok=True)
+                raise
+        return target
+
+    def _write_temp_file(self, target: Path, content: bytes) -> Path:
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{target.name}.",
+            suffix=".uploading",
+            dir=self.upload_dir,
+        )
+        tmp_path = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+        except Exception:
+            tmp_path.unlink(missing_ok=True)
+            raise
+        return tmp_path
+
+
+__all__ = ["AtomicUploadStore", "UnsafeUpload", "UploadConflict"]
+

--- a/tests/test_race_condition_upload_fix.py
+++ b/tests/test_race_condition_upload_fix.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from fixes.race_condition_upload_fix import AtomicUploadStore, UnsafeUpload, UploadConflict
+
+
+class AtomicUploadStoreTests(unittest.TestCase):
+    def test_rejects_path_traversal_and_unsafe_names(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = AtomicUploadStore(temp_dir, allowed_extensions={".txt"})
+
+            for name in ("../secret.txt", "subdir/file.txt", r"subdir\file.txt", "", "..", "bad\x00.txt"):
+                with self.subTest(name=name):
+                    with self.assertRaises(UnsafeUpload):
+                        store.save(name, b"payload")
+
+    def test_enforces_size_and_extension_policy(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = AtomicUploadStore(temp_dir, max_bytes=4, allowed_extensions={"txt"})
+
+            with self.assertRaises(UnsafeUpload):
+                store.save("payload.bin", b"ok")
+            with self.assertRaises(UnsafeUpload):
+                store.save("payload.txt", b"toolong")
+            with self.assertRaises(UnsafeUpload):
+                store.save("payload.txt", b"")
+
+    def test_single_winner_for_concurrent_same_name_uploads(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = AtomicUploadStore(temp_dir, allowed_extensions={".txt"})
+
+            def attempt(index: int) -> bytes | str:
+                payload = f"payload-{index}".encode()
+                try:
+                    return store.save("shared.txt", payload).read_bytes()
+                except UploadConflict:
+                    return "conflict"
+
+            with ThreadPoolExecutor(max_workers=12) as pool:
+                results = list(pool.map(attempt, range(12)))
+
+            winners = [item for item in results if isinstance(item, bytes)]
+            self.assertEqual(len(winners), 1)
+            self.assertEqual(results.count("conflict"), 11)
+            final_payload = Path(temp_dir, "shared.txt").read_bytes()
+            self.assertIn(final_payload, winners)
+            self.assertFalse(list(Path(temp_dir).glob("*.uploading")))
+
+    def test_overwrite_still_publishes_complete_new_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = AtomicUploadStore(temp_dir, allowed_extensions={".txt"})
+            target = store.save("note.txt", b"first")
+
+            same_target = store.save("note.txt", b"second", overwrite=True)
+
+            self.assertEqual(target, same_target)
+            self.assertEqual(same_target.read_bytes(), b"second")
+
+    def test_distinct_uploads_do_not_block_each_other(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = AtomicUploadStore(temp_dir, allowed_extensions={".txt"})
+
+            with ThreadPoolExecutor(max_workers=4) as pool:
+                paths = list(pool.map(lambda i: store.save(f"file-{i}.txt", b"x"), range(4)))
+
+            self.assertEqual(len({path.name for path in paths}), 4)
+            self.assertEqual(sorted(path.name for path in Path(temp_dir).iterdir()), [
+                "file-0.txt",
+                "file-1.txt",
+                "file-2.txt",
+                "file-3.txt",
+            ])
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
/claim #85

Fixes the race-condition file upload bounty by adding a dependency-free atomic upload helper.

Scope:
- validates upload filenames and extensions before touching disk
- holds a per-target lock across existence checks and publish
- writes to a same-directory temporary file and atomically publishes with os.replace
- rejects concurrent overwrite attempts when overwrite is disabled
- removes temporary files on failures

Verification:
```text
python -m unittest tests.test_race_condition_upload_fix -v
python -m py_compile fixes\race_condition_upload_fix.py tests\test_race_condition_upload_fix.py
git diff --check
```