### PR TITLE
fix: guard file downloads against traversal

### DIFF
--- a/fixes/path_traversal_download_fix.py
+++ b/fixes/path_traversal_download_fix.py
@@ -1,0 +1,98 @@
+"""Path traversal resistant download helper for issue #88.
+
+The vulnerable pattern is joining an attacker supplied path to a download
+directory and trusting string prefixes. This module decodes URL-encoded input,
+rejects absolute paths and traversal segments, resolves the final target, and
+serves it only if the resolved file remains under the configured base directory.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from urllib.parse import unquote
+
+
+SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._ -]{0,127}$")
+
+
+class UnsafeDownloadPath(ValueError):
+    """Raised when a requested download path is unsafe."""
+
+
+class DownloadNotFound(FileNotFoundError):
+    """Raised when a safe path does not point at a downloadable file."""
+
+
+class SafeDownloadStore:
+    """Resolve and read downloadable files without path traversal."""
+
+    def __init__(self, base_dir: str | os.PathLike[str]) -> None:
+        self.base_dir = Path(base_dir).resolve()
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    def resolve(self, user_path: str) -> Path:
+        """Return a canonical path under ``base_dir`` or raise.
+
+        The check happens after URL decoding and after filesystem resolution so
+        encoded traversal and symlink escapes are both blocked.
+        """
+
+        decoded = self._decode_user_path(user_path)
+        parts = self._safe_parts(decoded)
+        candidate = self.base_dir.joinpath(*parts).resolve()
+        try:
+            candidate.relative_to(self.base_dir)
+        except ValueError as exc:
+            raise UnsafeDownloadPath("requested file escapes the download directory") from exc
+        return candidate
+
+    def read_bytes(self, user_path: str) -> bytes:
+        target = self.resolve(user_path)
+        if not target.exists() or not target.is_file():
+            raise DownloadNotFound("download target is not a regular file")
+        return target.read_bytes()
+
+    @staticmethod
+    def _decode_user_path(user_path: str) -> str:
+        if not isinstance(user_path, str):
+            raise UnsafeDownloadPath("download path must be text")
+        value = user_path.strip()
+        for _ in range(4):
+            decoded = unquote(value)
+            if decoded == value:
+                break
+            value = decoded
+        if not value:
+            raise UnsafeDownloadPath("download path is empty")
+        if "\x00" in value or any(ord(ch) < 32 for ch in value):
+            raise UnsafeDownloadPath("download path contains control characters")
+        return value
+
+    @staticmethod
+    def _safe_parts(decoded_path: str) -> tuple[str, ...]:
+        if "\\" in decoded_path:
+            raise UnsafeDownloadPath("backslash path separators are not accepted")
+        if PurePosixPath(decoded_path).is_absolute() or PureWindowsPath(decoded_path).is_absolute():
+            raise UnsafeDownloadPath("absolute paths are not accepted")
+        if ":" in decoded_path:
+            raise UnsafeDownloadPath("drive and stream syntax is not accepted")
+
+        raw_parts = PurePosixPath(decoded_path).parts
+        parts: list[str] = []
+        for part in raw_parts:
+            if part in {"", "."}:
+                continue
+            if part == "..":
+                raise UnsafeDownloadPath("parent directory traversal is not accepted")
+            if not SAFE_SEGMENT_RE.fullmatch(part):
+                raise UnsafeDownloadPath("download path contains unsupported characters")
+            parts.append(part)
+        if not parts:
+            raise UnsafeDownloadPath("download path has no file component")
+        return tuple(parts)
+
+
+__all__ = ["SafeDownloadStore", "UnsafeDownloadPath", "DownloadNotFound"]
+

--- a/tests/test_path_traversal_download_fix.py
+++ b/tests/test_path_traversal_download_fix.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from fixes.path_traversal_download_fix import (
+    DownloadNotFound,
+    SafeDownloadStore,
+    UnsafeDownloadPath,
+)
+
+
+class SafeDownloadStoreTests(unittest.TestCase):
+    def test_reads_regular_file_under_base_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base = Path(temp_dir, "downloads")
+            target = base / "reports" / "summary 2026.txt"
+            target.parent.mkdir(parents=True)
+            target.write_bytes(b"safe report")
+            store = SafeDownloadStore(base)
+
+            self.assertEqual(store.read_bytes("reports/summary%202026.txt"), b"safe report")
+            self.assertEqual(store.resolve("reports/summary 2026.txt"), target.resolve())
+
+    def test_rejects_plain_and_encoded_traversal(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base = Path(temp_dir, "downloads")
+            base.mkdir()
+            Path(temp_dir, "secret.txt").write_text("secret", encoding="utf-8")
+            store = SafeDownloadStore(base)
+
+            for requested in (
+                "../secret.txt",
+                "reports/../../secret.txt",
+                "%2e%2e/secret.txt",
+                "%252e%252e%252fsecret.txt",
+                "reports/%2e%2e/%2e%2e/secret.txt",
+            ):
+                with self.subTest(requested=requested):
+                    with self.assertRaises(UnsafeDownloadPath):
+                        store.read_bytes(requested)
+
+    def test_rejects_absolute_windows_unc_and_control_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = SafeDownloadStore(Path(temp_dir, "downloads"))
+
+            for requested in (
+                "/etc/passwd",
+                "C:/Windows/win.ini",
+                r"C:\Windows\win.ini",
+                r"\\server\share\file.txt",
+                "safe\x00.txt",
+                "safe\n.txt",
+            ):
+                with self.subTest(requested=requested):
+                    with self.assertRaises(UnsafeDownloadPath):
+                        store.resolve(requested)
+
+    def test_rejects_directories_and_missing_files(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base = Path(temp_dir, "downloads")
+            Path(base, "nested").mkdir(parents=True)
+            store = SafeDownloadStore(base)
+
+            with self.assertRaises(DownloadNotFound):
+                store.read_bytes("nested")
+            with self.assertRaises(DownloadNotFound):
+                store.read_bytes("missing.txt")
+
+    def test_rejects_symlink_escape_after_resolution(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base = Path(temp_dir, "downloads")
+            base.mkdir()
+            outside = Path(temp_dir, "outside.txt")
+            outside.write_text("outside", encoding="utf-8")
+            link = base / "outside-link.txt"
+            try:
+                os.symlink(outside, link)
+            except OSError as exc:
+                self.skipTest(f"symlink creation unavailable: {exc}")
+            store = SafeDownloadStore(base)
+
+            with self.assertRaises(UnsafeDownloadPath):
+                store.read_bytes("outside-link.txt")
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
/claim #88

Fixes the path traversal file download bounty by adding a dependency-free safe download resolver.

Scope:
- repeatedly decodes URL-encoded paths before validation
- rejects absolute paths, Windows drive/UNC syntax, backslashes, control characters, and `..` traversal
- resolves the final target and enforces that it remains under the configured base directory
- serves only existing regular files
- includes coverage for plain traversal, encoded/double-encoded traversal, absolute paths, missing files, directories, and symlink escape behavior where OS permissions allow symlink creation

Verification:
```text
python -m unittest tests.test_path_traversal_download_fix -v
python -m py_compile fixes\path_traversal_download_fix.py tests\test_path_traversal_download_fix.py
git diff --check
```