### PR TITLE
fix: block jki auth bypass

### DIFF
--- a/fixes/jki_auth_bypass_fix.py
+++ b/fixes/jki_auth_bypass_fix.py
@@ -1,0 +1,124 @@
+"""Authentication-bypass guard for issue #117.
+
+The vulnerable pattern is treating a JWT header field such as ``jki``/``kid`` as
+a dynamic key lookup expression. Attackers can point the verifier at their own
+JWK, a remote JWKS URL, a filesystem path, or a database selector, then sign an
+admin token with the attacker-controlled key. This module resolves key ids only
+from a server-side registry and rejects every header-supplied key source.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+SAFE_KEY_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+SUPPORTED_ALGORITHMS = {"HS256": hashlib.sha256, "HS384": hashlib.sha384}
+INJECTABLE_KEY_HEADERS = {"jki", "jwk", "jku", "x5u", "x5c", "key", "public_key", "cert"}
+
+
+class AuthBypassBlocked(ValueError):
+    """Raised when a token attempts key-resolution or signature bypass."""
+
+
+@dataclass(frozen=True)
+class AuthKey:
+    key_id: str
+    algorithm: str
+    secret: bytes
+
+
+class SafeAuthTokenVerifier:
+    """Verify tokens without dynamic JKI/JWK key resolution."""
+
+    def __init__(self, keys: Mapping[str, AuthKey]) -> None:
+        self._keys = dict(keys)
+        for key_id, key in self._keys.items():
+            if key_id != key.key_id or not SAFE_KEY_ID_RE.fullmatch(key_id):
+                raise ValueError("registry key ids must be safe literals")
+            if key.algorithm not in SUPPORTED_ALGORITHMS:
+                raise ValueError("unsupported key algorithm")
+            if not key.secret:
+                raise ValueError("registry keys must have non-empty secrets")
+
+    def verify(self, token: str) -> dict[str, Any]:
+        header, claims, signing_input, signature = _decode_token(token)
+        key = self._resolve_registry_key(header)
+        expected = _signature(signing_input, key.secret, key.algorithm)
+        if not hmac.compare_digest(signature, expected):
+            raise AuthBypassBlocked("invalid signature")
+        return claims
+
+    def _resolve_registry_key(self, header: Mapping[str, Any]) -> AuthKey:
+        if INJECTABLE_KEY_HEADERS.intersection(header):
+            raise AuthBypassBlocked("token header must not supply keys or key locators")
+        if header.get("alg") not in SUPPORTED_ALGORITHMS:
+            raise AuthBypassBlocked("algorithm is not allowed")
+        key_id = header.get("kid")
+        if not isinstance(key_id, str) or not SAFE_KEY_ID_RE.fullmatch(key_id):
+            raise AuthBypassBlocked("kid must be a safe registry key id")
+        key = self._keys.get(key_id)
+        if key is None:
+            raise AuthBypassBlocked("unknown registry key id")
+        if header["alg"] != key.algorithm:
+            raise AuthBypassBlocked("algorithm does not match registry key")
+        return key
+
+
+def issue_token(claims: Mapping[str, Any], key: AuthKey, *, extra_header: Mapping[str, Any] | None = None) -> str:
+    header: dict[str, Any] = {"typ": "JWT", "alg": key.algorithm, "kid": key.key_id}
+    if extra_header:
+        header.update(extra_header)
+    signing_input = ".".join((_encode_json(header), _encode_json(dict(claims)))).encode("ascii")
+    return f"{signing_input.decode('ascii')}.{_encode(_signature(signing_input, key.secret, str(header['alg'])))}"
+
+
+def _decode_token(token: str) -> tuple[dict[str, Any], dict[str, Any], bytes, bytes]:
+    if not isinstance(token, str):
+        raise AuthBypassBlocked("token must be text")
+    parts = token.split(".")
+    if len(parts) != 3 or not all(parts):
+        raise AuthBypassBlocked("malformed token")
+    header = _decode_json(parts[0])
+    claims = _decode_json(parts[1])
+    if not isinstance(header, dict) or not isinstance(claims, dict):
+        raise AuthBypassBlocked("token segments must be JSON objects")
+    return header, claims, f"{parts[0]}.{parts[1]}".encode("ascii"), _decode(parts[2])
+
+
+def _signature(signing_input: bytes, secret: bytes, algorithm: str) -> bytes:
+    digest = SUPPORTED_ALGORITHMS.get(algorithm)
+    if digest is None:
+        raise AuthBypassBlocked("algorithm is not allowed")
+    return hmac.new(secret, signing_input, digest).digest()
+
+
+def _encode_json(value: Mapping[str, Any]) -> str:
+    return _encode(json.dumps(value, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+
+
+def _decode_json(value: str) -> Any:
+    try:
+        return json.loads(_decode(value))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise AuthBypassBlocked("invalid JSON segment") from exc
+
+
+def _encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _decode(value: str) -> bytes:
+    try:
+        return base64.urlsafe_b64decode((value + "=" * (-len(value) % 4)).encode("ascii"))
+    except (TypeError, ValueError) as exc:
+        raise AuthBypassBlocked("invalid base64url segment") from exc
+
+
+__all__ = ["AuthBypassBlocked", "AuthKey", "SafeAuthTokenVerifier", "issue_token"]

--- a/tests/test_jki_auth_bypass_fix.py
+++ b/tests/test_jki_auth_bypass_fix.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from fixes.jki_auth_bypass_fix import (
+    AuthBypassBlocked,
+    AuthKey,
+    SafeAuthTokenVerifier,
+    _encode,
+    issue_token,
+)
+
+
+class JKIAuthBypassTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.key = AuthKey("auth-main", "HS256", b"trusted-server-secret")
+        self.verifier = SafeAuthTokenVerifier({"auth-main": self.key})
+
+    def test_valid_registry_key_token_is_accepted(self) -> None:
+        token = issue_token({"sub": "user-1", "role": "member"}, self.key)
+
+        self.assertEqual(self.verifier.verify(token)["sub"], "user-1")
+
+    def test_header_jki_or_jwk_key_injection_is_rejected(self) -> None:
+        for header_name, value in (
+            ("jki", "https://evil.example/jwks.json#attacker"),
+            ("jwk", {"kty": "oct", "k": "attacker-secret"}),
+            ("jku", "https://evil.example/jwks.json"),
+            ("x5u", "file:///tmp/attacker.pem"),
+            ("public_key", "-----BEGIN PUBLIC KEY----- attacker"),
+        ):
+            token = issue_token({"sub": "admin"}, self.key, extra_header={header_name: value})
+            with self.subTest(header_name=header_name):
+                with self.assertRaisesRegex(AuthBypassBlocked, "must not supply"):
+                    self.verifier.verify(token)
+
+    def test_path_url_and_query_like_kid_values_are_rejected(self) -> None:
+        for kid in (
+            "../keys/admin.pem",
+            "https://evil.example/key",
+            "auth-main\nX-Injected: yes",
+            "auth-main;DROP TABLE keys",
+            "",
+        ):
+            token = issue_token({"sub": "admin"}, self.key, extra_header={"kid": kid})
+            with self.subTest(kid=kid):
+                with self.assertRaisesRegex(AuthBypassBlocked, "kid"):
+                    self.verifier.verify(token)
+
+    def test_unknown_safe_kid_does_not_trigger_dynamic_lookup(self) -> None:
+        attacker_key = AuthKey("attacker", "HS256", b"attacker-secret")
+        token = issue_token({"sub": "admin", "role": "admin"}, attacker_key)
+
+        with self.assertRaisesRegex(AuthBypassBlocked, "unknown"):
+            self.verifier.verify(token)
+
+    def test_algorithm_confusion_is_rejected_against_registry_key(self) -> None:
+        confused_key = AuthKey("auth-main", "HS384", b"trusted-server-secret")
+        token = issue_token({"sub": "admin"}, confused_key)
+
+        with self.assertRaisesRegex(AuthBypassBlocked, "algorithm does not match"):
+            self.verifier.verify(token)
+
+    def test_alg_none_unsigned_token_is_rejected(self) -> None:
+        header = _encode(json.dumps({"typ": "JWT", "alg": "none", "kid": "auth-main"}).encode())
+        claims = _encode(json.dumps({"sub": "admin", "role": "admin"}).encode())
+        token = f"{header}.{claims}.unsigned"
+
+        with self.assertRaisesRegex(AuthBypassBlocked, "algorithm"):
+            self.verifier.verify(token)
+
+    def test_payload_tampering_breaks_signature(self) -> None:
+        token = issue_token({"sub": "user-1", "role": "member"}, self.key)
+        header, _claims, signature = token.split(".")
+        admin_claims = _encode(json.dumps({"sub": "user-1", "role": "admin"}).encode())
+        tampered = f"{header}.{admin_claims}.{signature}"
+
+        with self.assertRaisesRegex(AuthBypassBlocked, "signature"):
+            self.verifier.verify(tampered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #117.

Scope:
- Adds a dependency-free JWT-style verifier that resolves keys only from a trusted server-side registry.
- Rejects attacker-controlled key locator headers including `jki`, `jwk`, `jku`, `x5u`, `x5c`, `key`, `public_key`, and `cert`.
- Restricts `kid` to short literal registry identifiers and rejects path, URL, query, newline, and injection-shaped values.
- Enforces the expected algorithm per registered key and rejects `alg=none`, unknown keys, algorithm confusion, and tampered signatures.
- Adds focused regression tests for the bypass cases.

Verification:
```text
python -m unittest tests.test_jki_auth_bypass_fix -v
python -m py_compile fixes\jki_auth_bypass_fix.py tests\test_jki_auth_bypass_fix.py
git diff --check
```
