### PR TITLE
fix: prevent template engine ssti rce

### DIFF
--- a/fixes/template_engine_ssti_rce_fix.py
+++ b/fixes/template_engine_ssti_rce_fix.py
@@ -1,0 +1,105 @@
+"""Safe template rendering boundary for issue #109.
+
+The vulnerable pattern is passing attacker-controlled strings into a template
+engine, where syntax such as ``{{ config.__class__.__mro__ }}`` can become code
+execution. This module keeps template source in a trusted server-side registry
+and treats all user input as escaped scalar data for simple placeholders only.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+import string
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+TEMPLATE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+FIELD_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
+MAX_VALUE_CHARS = 10_000
+
+
+class TemplatePolicyError(ValueError):
+    """Raised when a template or render context violates the safe policy."""
+
+
+@dataclass(frozen=True)
+class TrustedTemplate:
+    source: str
+    required_fields: frozenset[str]
+
+
+class SafeTemplateRenderer:
+    """Render only trusted templates with escaped scalar user data."""
+
+    def __init__(self, templates: Mapping[str, str]) -> None:
+        self._templates = {
+            template_id: TrustedTemplate(source, _extract_required_fields(source))
+            for template_id, source in templates.items()
+            if _validate_template_id(template_id)
+        }
+        if len(self._templates) != len(templates):
+            raise TemplatePolicyError("all template ids must be safe registry ids")
+
+    def render(self, template_id: str, context: Mapping[str, Any]) -> str:
+        if not _validate_template_id(template_id):
+            raise TemplatePolicyError("template id must be a safe registry id")
+        template = self._templates.get(template_id)
+        if template is None:
+            raise TemplatePolicyError("unknown template id")
+        safe_context = _sanitize_context(context, template.required_fields)
+        return template.source.format_map(safe_context)
+
+
+def _extract_required_fields(source: str) -> frozenset[str]:
+    if not isinstance(source, str) or not source:
+        raise TemplatePolicyError("template source must be non-empty text")
+    fields: set[str] = set()
+    formatter = string.Formatter()
+    for _literal, field_name, format_spec, conversion in formatter.parse(source):
+        if field_name is None:
+            continue
+        if not FIELD_NAME_RE.fullmatch(field_name):
+            raise TemplatePolicyError("template fields must be simple placeholder names")
+        if conversion is not None or format_spec:
+            raise TemplatePolicyError("conversions and format specs are not allowed")
+        fields.add(field_name)
+    return frozenset(fields)
+
+
+def _sanitize_context(context: Mapping[str, Any], required_fields: frozenset[str]) -> dict[str, str]:
+    if not isinstance(context, Mapping):
+        raise TemplatePolicyError("context must be a mapping")
+    supplied = set(context)
+    invalid_keys = {key for key in supplied if not isinstance(key, str) or not FIELD_NAME_RE.fullmatch(key)}
+    if invalid_keys:
+        raise TemplatePolicyError("context keys must be simple placeholder names")
+    missing = required_fields - supplied
+    if missing:
+        raise TemplatePolicyError("missing template context")
+    unexpected = supplied - required_fields
+    if unexpected:
+        raise TemplatePolicyError("unexpected template context")
+    return {key: _escape_scalar(context[key]) for key in required_fields}
+
+
+def _escape_scalar(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        text = "true" if value else "false"
+    elif isinstance(value, (str, int, float)):
+        text = str(value)
+    else:
+        raise TemplatePolicyError("context values must be scalar data")
+    if len(text) > MAX_VALUE_CHARS:
+        raise TemplatePolicyError("context value is too large")
+    return html.escape(text, quote=True)
+
+
+def _validate_template_id(template_id: str) -> bool:
+    return isinstance(template_id, str) and TEMPLATE_ID_RE.fullmatch(template_id) is not None
+
+
+__all__ = ["SafeTemplateRenderer", "TemplatePolicyError", "TrustedTemplate"]

--- a/tests/test_template_engine_ssti_rce_fix.py
+++ b/tests/test_template_engine_ssti_rce_fix.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import unittest
+
+from fixes.template_engine_ssti_rce_fix import SafeTemplateRenderer, TemplatePolicyError
+
+
+class SafeTemplateRendererTests(unittest.TestCase):
+    def test_renders_trusted_template_with_escaped_user_data(self) -> None:
+        renderer = SafeTemplateRenderer({"welcome": "<h1>Hello {name}</h1><p>{bio}</p>"})
+
+        html = renderer.render("welcome", {"name": "Ada", "bio": "<script>alert(1)</script>"})
+
+        self.assertEqual(html, "<h1>Hello Ada</h1><p>&lt;script&gt;alert(1)&lt;/script&gt;</p>")
+
+    def test_template_payload_in_user_data_is_not_executed(self) -> None:
+        renderer = SafeTemplateRenderer({"profile": "About: {description}"})
+        payload = "{{ config.__class__.__init__.__globals__['os'].system('id') }}"
+
+        html = renderer.render("profile", {"description": payload})
+
+        self.assertIn("config.__class__", html)
+        self.assertNotIn("uid=", html)
+
+    def test_unknown_or_path_like_template_id_is_rejected(self) -> None:
+        renderer = SafeTemplateRenderer({"invoice": "Total: {total}"})
+
+        for template_id in ("../invoice", "https://evil.example/tpl", "invoice.html", "missing"):
+            with self.subTest(template_id=template_id):
+                with self.assertRaises(TemplatePolicyError):
+                    renderer.render(template_id, {"total": 10})
+
+    def test_dynamic_template_source_is_not_accepted_as_template_id(self) -> None:
+        renderer = SafeTemplateRenderer({"safe": "Hello {name}"})
+
+        with self.assertRaises(TemplatePolicyError):
+            renderer.render("{{7*7}}", {"name": "Ada"})
+
+    def test_attribute_item_and_call_fields_are_rejected(self) -> None:
+        unsafe_templates = (
+            "{user.__class__}",
+            "{user[__class__]}",
+            "{user()}",
+            "{__import__}",
+            "{}",
+        )
+
+        for source in unsafe_templates:
+            with self.subTest(source=source):
+                with self.assertRaises(TemplatePolicyError):
+                    SafeTemplateRenderer({"unsafe": source})
+
+    def test_conversions_and_format_specs_are_rejected(self) -> None:
+        for source in ("{name!r}", "{amount:.2f}", "{name:{width}}"):
+            with self.subTest(source=source):
+                with self.assertRaises(TemplatePolicyError):
+                    SafeTemplateRenderer({"unsafe": source})
+
+    def test_missing_extra_or_unsafe_context_keys_are_rejected(self) -> None:
+        renderer = SafeTemplateRenderer({"safe": "Hello {name}"})
+
+        for context in ({}, {"name": "Ada", "extra": "x"}, {"name.__class__": "Ada"}):
+            with self.subTest(context=context):
+                with self.assertRaises(TemplatePolicyError):
+                    renderer.render("safe", context)
+
+    def test_object_callable_and_large_values_are_rejected(self) -> None:
+        renderer = SafeTemplateRenderer({"safe": "Hello {name}"})
+
+        for value in (object(), lambda: "Ada", "x" * 10_001):
+            with self.subTest(value_type=type(value).__name__):
+                with self.assertRaises(TemplatePolicyError):
+                    renderer.render("safe", {"name": value})
+
+    def test_scalar_values_are_normalized(self) -> None:
+        renderer = SafeTemplateRenderer({"safe": "{name}:{count}:{active}:{note}"})
+
+        html = renderer.render("safe", {"name": "Ada", "count": 3, "active": True, "note": None})
+
+        self.assertEqual(html, "Ada:3:true:")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #109.

Scope:
- Adds a dependency-free safe renderer for template-engine SSTI-to-RCE prevention.
- Keeps template source in a trusted server-side registry and renders by safe template id only.
- Allows only simple placeholders such as `{name}` and rejects attribute access, item lookup, calls, conversions, and format specs.
- Escapes all user-provided scalar values and rejects object/callable/oversized context data.
- Rejects unknown, path-like, URL-like, and dynamic template ids so attacker-controlled template text is never compiled.
- Adds focused regression tests for payload-as-data behavior and unsafe template/context rejection.

Verification:
```text
python -m unittest tests.test_template_engine_ssti_rce_fix -v
python -m py_compile fixes\template_engine_ssti_rce_fix.py tests\test_template_engine_ssti_rce_fix.py
git diff --check
```
