### PR TITLE
fix: prevent ldap auth injection

### DIFF
--- a/fixes/ldap_auth_injection_fix.py
+++ b/fixes/ldap_auth_injection_fix.py
@@ -1,0 +1,92 @@
+"""LDAP authentication filter guard for issue #87.
+
+LDAP injection happens when untrusted credentials are concatenated into filter
+syntax such as ``(&(uid={username})(userPassword={password}))``. Attackers can
+then inject wildcards, boolean clauses, or parentheses to bypass authentication.
+
+This module keeps authentication as a two-step process: build an escaped lookup
+filter for a constrained username, require exactly one account DN, and verify the
+password through a bind/check callback instead of embedding the password in LDAP
+filter syntax.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Callable, Iterable, Mapping
+
+
+USERNAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._@-]{0,127}$")
+ALLOWED_ACCOUNT_STATES = {"active", "enabled"}
+
+
+class LDAPAuthError(ValueError):
+    """Raised when authentication input or lookup results violate policy."""
+
+
+@dataclass(frozen=True)
+class LDAPAccount:
+    dn: str
+    attributes: Mapping[str, object]
+
+
+def escape_ldap_filter_value(value: object) -> str:
+    """Escape a value for use inside an LDAP filter assertion."""
+
+    if not isinstance(value, str):
+        raise LDAPAuthError("LDAP filter values must be text")
+    escaped: list[str] = []
+    for char in value:
+        if char == "*":
+            escaped.append(r"\2a")
+        elif char == "(":
+            escaped.append(r"\28")
+        elif char == ")":
+            escaped.append(r"\29")
+        elif char == "\\":
+            escaped.append(r"\5c")
+        elif char == "\x00":
+            escaped.append(r"\00")
+        else:
+            escaped.append(char)
+    return "".join(escaped)
+
+
+def build_user_lookup_filter(username: str, *, uid_attribute: str = "uid") -> str:
+    """Build a safe account lookup filter for an authentication request."""
+
+    if not isinstance(uid_attribute, str) or not re.fullmatch(r"[A-Za-z][A-Za-z0-9-]{0,31}", uid_attribute):
+        raise LDAPAuthError("uid attribute must be a safe schema attribute")
+    if not isinstance(username, str) or not USERNAME_RE.fullmatch(username):
+        raise LDAPAuthError("username contains unsafe LDAP filter syntax")
+    safe_username = escape_ldap_filter_value(username)
+    return f"(&({uid_attribute}={safe_username})(objectClass=person)(accountStatus=active))"
+
+
+def authenticate_user(
+    username: str,
+    password: str,
+    search_accounts: Callable[[str], Iterable[LDAPAccount]],
+    verify_password: Callable[[str, str], bool],
+) -> LDAPAccount:
+    """Authenticate without placing the password inside an LDAP filter."""
+
+    if not isinstance(password, str) or not password:
+        raise LDAPAuthError("password is required")
+    user_filter = build_user_lookup_filter(username)
+    accounts = list(search_accounts(user_filter))
+    if len(accounts) != 1:
+        raise LDAPAuthError("authentication requires exactly one account match")
+    account = accounts[0]
+    if not isinstance(account.dn, str) or not account.dn:
+        raise LDAPAuthError("account DN is invalid")
+    state = str(account.attributes.get("accountStatus", "")).lower()
+    if state not in ALLOWED_ACCOUNT_STATES:
+        raise LDAPAuthError("account is not active")
+    if not verify_password(account.dn, password):
+        raise LDAPAuthError("invalid credentials")
+    return account
+
+
+__all__ = ["LDAPAccount", "LDAPAuthError", "authenticate_user", "build_user_lookup_filter", "escape_ldap_filter_value"]

--- a/tests/test_ldap_auth_injection_fix.py
+++ b/tests/test_ldap_auth_injection_fix.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import unittest
+
+from fixes.ldap_auth_injection_fix import (
+    LDAPAccount,
+    LDAPAuthError,
+    authenticate_user,
+    build_user_lookup_filter,
+    escape_ldap_filter_value,
+)
+
+
+class LDAPAuthInjectionTests(unittest.TestCase):
+    def test_filter_values_escape_ldap_metacharacters(self) -> None:
+        self.assertEqual(escape_ldap_filter_value(r"*)(uid=*))(\x00"), r"\2a\29\28uid=\2a\29\29\28\5cx00")
+
+    def test_lookup_filter_contains_only_escaped_safe_username(self) -> None:
+        ldap_filter = build_user_lookup_filter("ada.lovelace@example.com")
+
+        self.assertEqual(
+            ldap_filter,
+            "(&(uid=ada.lovelace@example.com)(objectClass=person)(accountStatus=active))",
+        )
+
+    def test_injection_shaped_username_is_rejected_before_search(self) -> None:
+        searched: list[str] = []
+
+        def search_accounts(ldap_filter: str) -> list[LDAPAccount]:
+            searched.append(ldap_filter)
+            return []
+
+        with self.assertRaisesRegex(LDAPAuthError, "username"):
+            authenticate_user("*)(uid=*))(|(uid=*", "secret", search_accounts, lambda _dn, _pw: True)
+
+        self.assertEqual(searched, [])
+
+    def test_password_is_not_embedded_in_ldap_filter(self) -> None:
+        seen_filters: list[str] = []
+
+        def search_accounts(ldap_filter: str) -> list[LDAPAccount]:
+            seen_filters.append(ldap_filter)
+            return [LDAPAccount("uid=ada,ou=people,dc=example,dc=com", {"accountStatus": "active"})]
+
+        account = authenticate_user("ada", "p@ss*)(uid=*))", search_accounts, lambda dn, pw: dn.startswith("uid=ada") and pw)
+
+        self.assertEqual(account.dn, "uid=ada,ou=people,dc=example,dc=com")
+        self.assertNotIn("p@ss", seen_filters[0])
+
+    def test_authentication_requires_exactly_one_result(self) -> None:
+        for results in (
+            [],
+            [
+                LDAPAccount("uid=a,ou=people,dc=example,dc=com", {"accountStatus": "active"}),
+                LDAPAccount("uid=b,ou=people,dc=example,dc=com", {"accountStatus": "active"}),
+            ],
+        ):
+            with self.subTest(count=len(results)):
+                with self.assertRaisesRegex(LDAPAuthError, "exactly one"):
+                    authenticate_user("ada", "secret", lambda _filter: results, lambda _dn, _pw: True)
+
+    def test_disabled_account_is_rejected(self) -> None:
+        account = LDAPAccount("uid=ada,ou=people,dc=example,dc=com", {"accountStatus": "disabled"})
+
+        with self.assertRaisesRegex(LDAPAuthError, "active"):
+            authenticate_user("ada", "secret", lambda _filter: [account], lambda _dn, _pw: True)
+
+    def test_password_verifier_failure_is_rejected(self) -> None:
+        account = LDAPAccount("uid=ada,ou=people,dc=example,dc=com", {"accountStatus": "active"})
+
+        with self.assertRaisesRegex(LDAPAuthError, "invalid credentials"):
+            authenticate_user("ada", "wrong", lambda _filter: [account], lambda _dn, _pw: False)
+
+    def test_safe_schema_attribute_is_required(self) -> None:
+        for attr in ("uid)(|(uid", "1uid", "uid*", "distinguishedName.long"):
+            with self.subTest(attr=attr):
+                with self.assertRaisesRegex(LDAPAuthError, "attribute"):
+                    build_user_lookup_filter("ada", uid_attribute=attr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #87.

Scope:
- Adds a dependency-free LDAP authentication guard for injection-safe account lookup.
- Escapes LDAP filter metacharacters using RFC4515-style encodings.
- Constrains usernames and LDAP schema attribute names before any search occurs.
- Looks up the account with an escaped user filter, requires exactly one active result, and verifies the password via a bind/check callback instead of embedding the password in LDAP filter syntax.
- Adds regression tests for injection-shaped usernames, escaped filter values, password-filter separation, multi-match/no-match failures, disabled accounts, verifier failure, and unsafe schema attributes.

Verification:
```text
python -m unittest tests.test_ldap_auth_injection_fix -v
python -m py_compile fixes\ldap_auth_injection_fix.py tests\test_ldap_auth_injection_fix.py
git diff --check
```
