### PR TITLE
fix: prevent mass assignment privilege escalation

### DIFF
--- a/fixes/mass_assignment_microservice_chain_fix.py
+++ b/fixes/mass_assignment_microservice_chain_fix.py
@@ -1,0 +1,174 @@
+"""Mass-assignment guard for issue #256.
+
+The vulnerable pattern is binding an untrusted profile-update payload directly
+onto a shared user/account object. In a microservice chain, attacker supplied
+fields such as ``role``, ``is_admin``, ``tenant_id``, or ``permissions`` can
+propagate to downstream authorization services and become a privilege
+escalation. This module keeps the trust boundary at the HTTP edge: only an
+explicit public allowlist is writable, and identity/privilege fields are always
+server-controlled.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any, Mapping
+
+
+class MassAssignmentViolation(ValueError):
+    """Raised when a payload attempts to write fields outside policy."""
+
+    def __init__(self, message: str, fields: list[str]) -> None:
+        super().__init__(message)
+        self.fields = tuple(sorted(set(fields)))
+
+
+@dataclass(frozen=True)
+class Account:
+    user_id: str
+    email: str
+    tenant_id: str
+    role: str
+    is_admin: bool = False
+    display_name: str = ""
+    bio: str = ""
+    timezone: str = "UTC"
+    marketing_opt_in: bool = False
+
+
+PUBLIC_PROFILE_SCHEMA: Mapping[str, type] = {
+    "display_name": str,
+    "bio": str,
+    "timezone": str,
+    "marketing_opt_in": bool,
+}
+
+SERVER_CONTROLLED_FIELDS = {
+    "id",
+    "user_id",
+    "email",
+    "tenant_id",
+    "org_id",
+    "organization_id",
+    "account_id",
+    "role",
+    "roles",
+    "is_admin",
+    "is_superuser",
+    "is_staff",
+    "permissions",
+    "scopes",
+    "plan",
+    "billing_tier",
+    "quota",
+    "password",
+    "password_hash",
+    "mfa_secret",
+    "api_key",
+    "created_at",
+    "updated_at",
+}
+
+
+def apply_public_profile_update(account: Account, payload: Mapping[str, Any]) -> Account:
+    """Return an updated account after validating a public profile payload."""
+
+    clean = sanitize_public_profile_update(payload)
+    return replace(account, **clean)
+
+
+def sanitize_public_profile_update(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate and filter a user-controlled update payload.
+
+    Unknown fields are rejected rather than silently dropped. Failing closed
+    lets callers log attacks and prevents later microservices from accepting a
+    partially-mutated account object.
+    """
+
+    if not isinstance(payload, Mapping):
+        raise MassAssignmentViolation("payload must be an object", ["<payload>"])
+
+    forbidden: list[str] = []
+    clean: dict[str, Any] = {}
+    for raw_key, value in payload.items():
+        if not isinstance(raw_key, str):
+            forbidden.append("<non-string-key>")
+            continue
+
+        canonical = _canonical_key(raw_key)
+        if _is_suspicious_key(raw_key) or canonical in SERVER_CONTROLLED_FIELDS:
+            forbidden.append(raw_key)
+            continue
+
+        expected_type = PUBLIC_PROFILE_SCHEMA.get(canonical)
+        if expected_type is None:
+            forbidden.append(raw_key)
+            continue
+
+        if not isinstance(value, expected_type) or isinstance(value, (dict, list, tuple, set)):
+            forbidden.append(raw_key)
+            continue
+
+        if isinstance(value, str) and len(value) > 512:
+            forbidden.append(raw_key)
+            continue
+
+        clean[canonical] = value
+
+    if forbidden:
+        raise MassAssignmentViolation("mass-assignment payload contains forbidden fields", forbidden)
+
+    return clean
+
+
+def build_auth_profile_event(account: Account) -> dict[str, Any]:
+    """Build the downstream auth event from trusted account state only."""
+
+    return {
+        "user_id": account.user_id,
+        "email": account.email,
+        "tenant_id": account.tenant_id,
+        "role": account.role,
+        "is_admin": account.is_admin,
+        "profile": {
+            "display_name": account.display_name,
+            "bio": account.bio,
+            "timezone": account.timezone,
+            "marketing_opt_in": account.marketing_opt_in,
+        },
+    }
+
+
+def vulnerable_bind(account: Account, payload: Mapping[str, Any]) -> Account:
+    """Model the dangerous ORM-style bind used by tests to prove the bug."""
+
+    updates = {key: value for key, value in payload.items() if hasattr(account, str(key))}
+    return replace(account, **updates)
+
+
+def _canonical_key(key: str) -> str:
+    return key.strip().lower().replace("-", "_")
+
+
+def _is_suspicious_key(key: str) -> bool:
+    compact = key.replace("-", "_").lower()
+    return (
+        "__" in compact
+        or "." in key
+        or "[" in key
+        or "]" in key
+        or "$" in key
+        or "prototype" in compact
+        or "constructor" in compact
+        or any(ord(ch) < 32 for ch in key)
+    )
+
+
+__all__ = [
+    "Account",
+    "MassAssignmentViolation",
+    "apply_public_profile_update",
+    "build_auth_profile_event",
+    "sanitize_public_profile_update",
+    "vulnerable_bind",
+]

--- a/tests/test_mass_assignment_microservice_chain_fix.py
+++ b/tests/test_mass_assignment_microservice_chain_fix.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import unittest
+
+from fixes.mass_assignment_microservice_chain_fix import (
+    Account,
+    MassAssignmentViolation,
+    apply_public_profile_update,
+    build_auth_profile_event,
+    sanitize_public_profile_update,
+    vulnerable_bind,
+)
+
+
+class MassAssignmentMicroserviceChainFixTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.account = Account(
+            user_id="u-123",
+            email="user@example.com",
+            tenant_id="tenant-a",
+            role="member",
+            is_admin=False,
+            display_name="Original",
+        )
+
+    def test_public_profile_fields_are_applied(self) -> None:
+        updated = apply_public_profile_update(
+            self.account,
+            {"display_name": "Ada", "bio": "Builder", "timezone": "America/Chicago", "marketing_opt_in": True},
+        )
+
+        self.assertEqual(updated.display_name, "Ada")
+        self.assertEqual(updated.bio, "Builder")
+        self.assertEqual(updated.timezone, "America/Chicago")
+        self.assertTrue(updated.marketing_opt_in)
+        self.assertEqual(updated.role, "member")
+        self.assertFalse(updated.is_admin)
+
+    def test_privilege_fields_are_rejected(self) -> None:
+        payload = {"display_name": "Eve", "role": "owner", "is_admin": True, "tenant_id": "tenant-b"}
+
+        with self.assertRaises(MassAssignmentViolation) as ctx:
+            sanitize_public_profile_update(payload)
+
+        self.assertEqual(set(ctx.exception.fields), {"role", "is_admin", "tenant_id"})
+
+    def test_case_and_dash_variants_of_server_fields_are_rejected(self) -> None:
+        for key in ("ROLE", "is-admin", "Tenant_ID", "permissions"):
+            with self.subTest(key=key):
+                with self.assertRaises(MassAssignmentViolation):
+                    sanitize_public_profile_update({key: "attacker"})
+
+    def test_unknown_and_suspicious_keys_are_rejected(self) -> None:
+        for key in ("profile.role", "profile[role]", "$set", "__proto__", "constructor.prototype.role", "nickname"):
+            with self.subTest(key=key):
+                with self.assertRaises(MassAssignmentViolation):
+                    sanitize_public_profile_update({key: "admin"})
+
+    def test_nested_values_cannot_be_smuggled_into_scalar_profile_fields(self) -> None:
+        with self.assertRaises(MassAssignmentViolation):
+            sanitize_public_profile_update({"display_name": {"$ne": ""}})
+
+    def test_wrong_types_are_rejected(self) -> None:
+        with self.assertRaises(MassAssignmentViolation):
+            sanitize_public_profile_update({"marketing_opt_in": "true"})
+
+    def test_downstream_auth_event_uses_trusted_account_state_only(self) -> None:
+        updated = apply_public_profile_update(self.account, {"display_name": "Safe Name"})
+        event = build_auth_profile_event(updated)
+
+        self.assertEqual(event["role"], "member")
+        self.assertFalse(event["is_admin"])
+        self.assertEqual(event["tenant_id"], "tenant-a")
+        self.assertEqual(event["profile"]["display_name"], "Safe Name")
+
+    def test_vulnerable_bind_demonstrates_privilege_escalation_vector(self) -> None:
+        compromised = vulnerable_bind(self.account, {"role": "owner", "is_admin": True})
+
+        self.assertEqual(compromised.role, "owner")
+        self.assertTrue(compromised.is_admin)
+
+        with self.assertRaises(MassAssignmentViolation):
+            apply_public_profile_update(self.account, {"role": "owner", "is_admin": True})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #256.

Scope:
- Adds a dependency-free mass-assignment guard for profile updates in a microservice chain.
- Allows only explicit public profile fields.
- Rejects server-controlled identity and privilege fields such as `role`, `is_admin`, `tenant_id`, `permissions`, secrets, and audit fields.
- Rejects suspicious nested/operator keys such as `profile.role`, `profile[role]`, `$set`, `__proto__`, and `constructor.prototype`.
- Type-checks accepted profile fields and builds downstream auth events from trusted account state only.
- Includes a vulnerable bind helper in tests to demonstrate the escalation vector that the guard blocks.

Verification:
```text
python -m unittest tests.test_mass_assignment_microservice_chain_fix -v
python -c "from pathlib import Path; [compile(Path(p).read_text(), p, 'exec') for p in ['fixes/mass_assignment_microservice_chain_fix.py','tests/test_mass_assignment_microservice_chain_fix.py']]"
git diff --check
```
