### PR TITLE
fix: prevent xs search enumeration

### DIFF
--- a/fixes/xs_search_enumeration_fix.py
+++ b/fixes/xs_search_enumeration_fix.py
@@ -1,0 +1,127 @@
+"""XS-Search mitigation for issue #255.
+
+Cross-Site Search attacks exploit observable differences in search endpoints:
+status codes, result counts, response sizes, cache state, or timing can reveal
+whether a victim has private data matching an attacker-chosen query. The safe
+pattern is to require same-site authenticated requests for real results and to
+return a constant opaque response for cross-site or unauthenticated probes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+
+TRUSTED_ORIGIN = "https://app.example.com"
+SAFE_EMPTY_BODY = '{"results":[],"next":null}'
+SAFE_HEADERS = {
+    "Cache-Control": "no-store, private",
+    "Content-Type": "application/json",
+    "Cross-Origin-Resource-Policy": "same-origin",
+    "Vary": "Origin, Sec-Fetch-Site, Cookie, Authorization",
+    "X-Content-Type-Options": "nosniff",
+}
+
+
+@dataclass(frozen=True)
+class SearchDocument:
+    owner_id: str
+    title: str
+    body: str
+
+
+@dataclass(frozen=True)
+class RequestContext:
+    user_id: str | None
+    origin: str | None
+    sec_fetch_site: str | None
+    has_session_cookie: bool
+    csrf_token_valid: bool
+
+
+@dataclass(frozen=True)
+class SearchResponse:
+    status: int
+    body: str
+    headers: Mapping[str, str]
+    results: tuple[SearchDocument, ...] = ()
+
+
+def safe_private_search(query: str, context: RequestContext, documents: Iterable[SearchDocument]) -> SearchResponse:
+    """Search private documents without leaking existence to cross-site probes."""
+
+    if not _is_same_site_authenticated(context):
+        return _opaque_empty_response()
+
+    clean_query = _normalize_query(query)
+    if not clean_query:
+        return _authorized_response(())
+
+    matches = tuple(
+        doc
+        for doc in documents
+        if doc.owner_id == context.user_id and (clean_query in doc.title.lower() or clean_query in doc.body.lower())
+    )
+    return _authorized_response(matches)
+
+
+def vulnerable_private_search_count(query: str, context: RequestContext, documents: Iterable[SearchDocument]) -> int:
+    """Model the unsafe search-count leak used by regression tests."""
+
+    clean_query = _normalize_query(query)
+    return sum(
+        1
+        for doc in documents
+        if doc.owner_id == context.user_id and clean_query and (clean_query in doc.title.lower() or clean_query in doc.body.lower())
+    )
+
+
+def _is_same_site_authenticated(context: RequestContext) -> bool:
+    if not context.user_id or not context.has_session_cookie or not context.csrf_token_valid:
+        return False
+    if context.origin != TRUSTED_ORIGIN:
+        return False
+    return context.sec_fetch_site in {"same-origin", "same-site", None}
+
+
+def _opaque_empty_response() -> SearchResponse:
+    return SearchResponse(status=200, body=SAFE_EMPTY_BODY, headers=SAFE_HEADERS, results=())
+
+
+def _authorized_response(results: Iterable[SearchDocument]) -> SearchResponse:
+    result_tuple = tuple(results)
+    body = '{"results":[' + ",".join(_document_json(doc) for doc in result_tuple) + '],"next":null}'
+    return SearchResponse(status=200, body=body, headers=SAFE_HEADERS, results=result_tuple)
+
+
+def _normalize_query(query: str) -> str:
+    if not isinstance(query, str):
+        return ""
+    return " ".join(query.lower().split())[:128]
+
+
+def _document_json(doc: SearchDocument) -> str:
+    return (
+        '{"title":"'
+        + _json_escape(doc.title)
+        + '","body":"'
+        + _json_escape(doc.body)
+        + '"}'
+    )
+
+
+def _json_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "\\r")
+
+
+__all__ = [
+    "RequestContext",
+    "SearchDocument",
+    "SearchResponse",
+    "SAFE_EMPTY_BODY",
+    "SAFE_HEADERS",
+    "TRUSTED_ORIGIN",
+    "safe_private_search",
+    "vulnerable_private_search_count",
+]

--- a/tests/test_xs_search_enumeration_fix.py
+++ b/tests/test_xs_search_enumeration_fix.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import unittest
+
+from fixes.xs_search_enumeration_fix import (
+    SAFE_EMPTY_BODY,
+    TRUSTED_ORIGIN,
+    RequestContext,
+    SearchDocument,
+    safe_private_search,
+    vulnerable_private_search_count,
+)
+
+
+class XSSearchEnumerationFixTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.documents = [
+            SearchDocument("victim", "Payroll memo", "confidential raise discussion"),
+            SearchDocument("victim", "Travel", "Paris itinerary"),
+            SearchDocument("other", "Payroll memo", "other tenant data"),
+        ]
+        self.same_site = RequestContext(
+            user_id="victim",
+            origin=TRUSTED_ORIGIN,
+            sec_fetch_site="same-origin",
+            has_session_cookie=True,
+            csrf_token_valid=True,
+        )
+
+    def test_authorized_same_site_search_returns_private_matches(self) -> None:
+        response = safe_private_search("payroll", self.same_site, self.documents)
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(len(response.results), 1)
+        self.assertIn("Payroll memo", response.body)
+        self.assertNotIn("other tenant", response.body)
+
+    def test_cross_site_probe_gets_constant_empty_response_for_matching_query(self) -> None:
+        cross_site = RequestContext("victim", "https://attacker.example", "cross-site", True, True)
+
+        response = safe_private_search("payroll", cross_site, self.documents)
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.body, SAFE_EMPTY_BODY)
+        self.assertEqual(response.results, ())
+
+    def test_cross_site_responses_are_identical_for_hit_and_miss(self) -> None:
+        cross_site = RequestContext("victim", "https://attacker.example", "cross-site", True, True)
+
+        hit = safe_private_search("payroll", cross_site, self.documents)
+        miss = safe_private_search("definitely-not-present", cross_site, self.documents)
+
+        self.assertEqual(hit.status, miss.status)
+        self.assertEqual(hit.body, miss.body)
+        self.assertEqual(dict(hit.headers), dict(miss.headers))
+
+    def test_missing_session_or_csrf_token_is_opaque(self) -> None:
+        for context in (
+            RequestContext("victim", TRUSTED_ORIGIN, "same-origin", False, True),
+            RequestContext("victim", TRUSTED_ORIGIN, "same-origin", True, False),
+            RequestContext(None, TRUSTED_ORIGIN, "same-origin", True, True),
+        ):
+            with self.subTest(context=context):
+                response = safe_private_search("payroll", context, self.documents)
+                self.assertEqual(response.body, SAFE_EMPTY_BODY)
+
+    def test_fetch_metadata_blocks_cross_site_even_with_cookie(self) -> None:
+        context = RequestContext("victim", TRUSTED_ORIGIN, "cross-site", True, True)
+
+        response = safe_private_search("payroll", context, self.documents)
+
+        self.assertEqual(response.body, SAFE_EMPTY_BODY)
+
+    def test_safe_headers_disable_cache_and_cross_origin_reads(self) -> None:
+        response = safe_private_search("payroll", self.same_site, self.documents)
+
+        self.assertEqual(response.headers["Cache-Control"], "no-store, private")
+        self.assertEqual(response.headers["Cross-Origin-Resource-Policy"], "same-origin")
+        self.assertIn("Origin", response.headers["Vary"])
+        self.assertIn("Sec-Fetch-Site", response.headers["Vary"])
+
+    def test_vulnerable_count_leaks_private_data_existence(self) -> None:
+        hit = vulnerable_private_search_count("payroll", self.same_site, self.documents)
+        miss = vulnerable_private_search_count("definitely-not-present", self.same_site, self.documents)
+
+        self.assertEqual(hit, 1)
+        self.assertEqual(miss, 0)
+
+    def test_query_is_normalized_and_limited(self) -> None:
+        response = safe_private_search("  PAYROLL\nmemo  " + "x" * 300, self.same_site, self.documents)
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.results, ())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #255.

Scope:
- Adds a dependency-free XS-Search mitigation for private search endpoints.
- Requires same-site authenticated requests with a valid CSRF token before returning private results.
- Returns a constant opaque empty response for cross-site, unauthenticated, missing-CSRF, or invalid Fetch Metadata probes.
- Keeps response status, body, headers, and result shape identical for cross-site hit and miss queries.
- Adds `no-store`, `Cross-Origin-Resource-Policy: same-origin`, `Vary`, and `nosniff` headers to reduce observable cache and cross-origin side channels.
- Includes a vulnerable count helper in tests to demonstrate the enumeration leak.

Verification:
```text
python -m unittest tests.test_xs_search_enumeration_fix -v
python -c "from pathlib import Path; [compile(Path(p).read_text(), p, 'exec') for p in ['fixes/xs_search_enumeration_fix.py','tests/test_xs_search_enumeration_fix.py']]"
git diff --check
```
