### PR TITLE
fix: prevent password clipboard exposure

### DIFF
--- a/fixes/password_clipboard_autocomplete_fix.js
+++ b/fixes/password_clipboard_autocomplete_fix.js
@@ -1,0 +1,106 @@
+"use strict";
+
+const SECRET_FIELD_SELECTOR = '[data-secret-field="true"], input[type="password"], textarea[data-secret-field="true"]';
+
+function securePasswordFieldAttributes() {
+  return {
+    type: "password",
+    autocomplete: "new-password",
+    spellcheck: "false",
+    autocapitalize: "off",
+    "data-secret-field": "true",
+  };
+}
+
+function passwordInputMarkup(name = "password", id = name) {
+  return [
+    `<input type="password" id="${escapeAttribute(id)}" name="${escapeAttribute(name)}"`,
+    ' autocomplete="new-password"',
+    ' spellcheck="false"',
+    ' autocapitalize="off"',
+    ' data-secret-field="true"',
+    " />",
+  ].join("");
+}
+
+function installSecretClipboardGuards(root = globalThis.document) {
+  if (!root || typeof root.addEventListener !== "function") {
+    throw new TypeError("A DOM root with addEventListener is required");
+  }
+
+  for (const eventName of ["copy", "cut", "dragstart", "contextmenu"]) {
+    root.addEventListener(eventName, blockSecretClipboardEvent, true);
+  }
+
+  return () => {
+    if (typeof root.removeEventListener !== "function") return;
+    for (const eventName of ["copy", "cut", "dragstart", "contextmenu"]) {
+      root.removeEventListener(eventName, blockSecretClipboardEvent, true);
+    }
+  };
+}
+
+function blockSecretClipboardEvent(event) {
+  if (!event || !isSecretField(event.target)) {
+    return true;
+  }
+
+  if (typeof event.preventDefault === "function") {
+    event.preventDefault();
+  }
+  if (typeof event.stopPropagation === "function") {
+    event.stopPropagation();
+  }
+  if (event.clipboardData && typeof event.clipboardData.clearData === "function") {
+    event.clipboardData.clearData();
+  }
+  return false;
+}
+
+async function copyNonSecretText(source, clipboard = globalThis.navigator?.clipboard) {
+  if (isSecretField(source)) {
+    throw new Error("Refusing to copy a secret field to the clipboard");
+  }
+  if (!clipboard || typeof clipboard.writeText !== "function") {
+    throw new TypeError("A clipboard with writeText is required");
+  }
+
+  const value = typeof source === "string" ? source : source?.value ?? source?.textContent ?? "";
+  await clipboard.writeText(String(value));
+}
+
+function isSecretField(element) {
+  if (!element) return false;
+
+  if (typeof element.matches === "function" && element.matches(SECRET_FIELD_SELECTOR)) {
+    return true;
+  }
+  if (String(element.tagName || "").toLowerCase() === "input" && String(element.type || "").toLowerCase() === "password") {
+    return true;
+  }
+  if (element.dataset && element.dataset.secretField === "true") {
+    return true;
+  }
+  if (typeof element.closest === "function") {
+    return Boolean(element.closest(SECRET_FIELD_SELECTOR));
+  }
+  return false;
+}
+
+function escapeAttribute(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+module.exports = {
+  SECRET_FIELD_SELECTOR,
+  blockSecretClipboardEvent,
+  copyNonSecretText,
+  installSecretClipboardGuards,
+  isSecretField,
+  passwordInputMarkup,
+  securePasswordFieldAttributes,
+};

--- a/tests/test_password_clipboard_autocomplete_fix.js
+++ b/tests/test_password_clipboard_autocomplete_fix.js
@@ -1,0 +1,133 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+
+const {
+  blockSecretClipboardEvent,
+  copyNonSecretText,
+  installSecretClipboardGuards,
+  isSecretField,
+  passwordInputMarkup,
+  securePasswordFieldAttributes,
+} = require("../fixes/password_clipboard_autocomplete_fix.js");
+
+describe("password clipboard/autocomplete fix", () => {
+  it("uses password-safe autocomplete and secret-field attributes", () => {
+    assert.deepEqual(securePasswordFieldAttributes(), {
+      type: "password",
+      autocomplete: "new-password",
+      spellcheck: "false",
+      autocapitalize: "off",
+      "data-secret-field": "true",
+    });
+  });
+
+  it("detects password and explicitly marked secret fields", () => {
+    assert.equal(isSecretField({ tagName: "INPUT", type: "password" }), true);
+    assert.equal(isSecretField({ dataset: { secretField: "true" } }), true);
+    assert.equal(
+      isSecretField({
+        tagName: "span",
+        type: "",
+        closest(selector) {
+          return selector.includes("data-secret-field") ? { nodeName: "label" } : null;
+        },
+      }),
+      true,
+    );
+    assert.equal(isSecretField({ tagName: "INPUT", type: "text" }), false);
+  });
+
+  it("blocks copy events from password fields and clears clipboard data", () => {
+    let prevented = false;
+    let stopped = false;
+    let cleared = false;
+    const allowed = blockSecretClipboardEvent({
+      target: { tagName: "input", type: "password" },
+      preventDefault() {
+        prevented = true;
+      },
+      stopPropagation() {
+        stopped = true;
+      },
+      clipboardData: {
+        clearData() {
+          cleared = true;
+        },
+      },
+    });
+
+    assert.equal(allowed, false);
+    assert.equal(prevented, true);
+    assert.equal(stopped, true);
+    assert.equal(cleared, true);
+  });
+
+  it("does not block copy events from non-secret fields", () => {
+    let prevented = false;
+    const allowed = blockSecretClipboardEvent({
+      target: { tagName: "input", type: "text" },
+      preventDefault() {
+        prevented = true;
+      },
+    });
+
+    assert.equal(allowed, true);
+    assert.equal(prevented, false);
+  });
+
+  it("safe copy helper refuses secret fields and writes non-secret text", async () => {
+    const writes = [];
+    const clipboard = {
+      async writeText(value) {
+        writes.push(value);
+      },
+    };
+
+    await copyNonSecretText({ tagName: "input", type: "text", value: "public username" }, clipboard);
+    await assert.rejects(
+      () => copyNonSecretText({ tagName: "input", type: "password", value: "super-secret" }, clipboard),
+      /Refusing to copy a secret field/,
+    );
+
+    assert.deepEqual(writes, ["public username"]);
+  });
+
+  it("installs and removes capture-phase guards", () => {
+    const added = [];
+    const removed = [];
+    const root = {
+      addEventListener(name, handler, capture) {
+        added.push([name, handler, capture]);
+      },
+      removeEventListener(name, handler, capture) {
+        removed.push([name, handler, capture]);
+      },
+    };
+
+    const uninstall = installSecretClipboardGuards(root);
+    uninstall();
+
+    assert.deepEqual(
+      added.map(([name, , capture]) => [name, capture]),
+      [
+        ["copy", true],
+        ["cut", true],
+        ["dragstart", true],
+        ["contextmenu", true],
+      ],
+    );
+    assert.equal(removed.length, 4);
+  });
+
+  it("renders safe password input markup without embedding values", () => {
+    const html = passwordInputMarkup('pa"ss', "login-password");
+
+    assert.match(html, /type="password"/);
+    assert.match(html, /autocomplete="new-password"/);
+    assert.match(html, /data-secret-field="true"/);
+    assert.doesNotMatch(html, /value=/);
+    assert.match(html, /name="pa&quot;ss"/);
+  });
+});


### PR DESCRIPTION
Fixes #97.

## Summary

- Adds a dependency-free browser-side guard for password fields.
- Provides safe password field attributes: `type="password"`, `autocomplete="new-password"`, `spellcheck="false"`, `autocapitalize="off"`, and `data-secret-field="true"`.
- Blocks `copy`, `cut`, `dragstart`, and `contextmenu` events from password/secret fields in the capture phase.
- Clears clipboard data on blocked copy/cut events where the browser exposes `clipboardData`.
- Adds a shared `copyNonSecretText` helper that refuses to copy password/secret fields to `navigator.clipboard`.
- Renders password input markup without embedding a `value`, so secrets are not placed in HTML.

## Verification

```text
node --test tests\test_password_clipboard_autocomplete_fix.js
node --check fixes\password_clipboard_autocomplete_fix.js
node --check tests\test_password_clipboard_autocomplete_fix.js
git diff --check
```

Result: 7 tests passed; syntax checks passed; whitespace check passed.

Payment details are available on request if accepted for the listed bounty.
