### PR TITLE
fix: Clickjacking → Crypto Withdrawal Protection (fixes #727)

### DIFF
--- a/FIXES/fix_access_log_crlf.py
+++ b/FIXES/fix_access_log_crlf.py
@@ -1,0 +1,246 @@
+"""
+fix_access_log_crlf.py — Access Log CRLF Injection → HTTP Response Splitting Fix
+
+Issue #681 — Access log writes User-Agent directly into response header:
+  res.setHeader("X-Log", userAgent)
+
+Attackers inject CRLF (%0d%0a) sequences via User-Agent to split the HTTP
+response, allowing arbitrary header/body injection and cache poisoning.
+
+FIX:
+1. Strip/reject CRLF sequences from all user-controlled header values
+2. Never write raw user input into response headers — use safe wrapper
+3. Encode dangerous characters with encodeURIComponent-style sanitization
+4. Log to file instead of response header for access tracking
+"""
+
+from __future__ import annotations
+
+import html
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Dict, Optional, Tuple
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Configuration
+# ═══════════════════════════════════════════════════════════════════
+
+# CRLF and control character patterns
+CRLF_PATTERN = re.compile(r"[\r\n\x0d\x0a]")
+URL_ENCODED_CRLF = re.compile(r"%0[ddD]%0[aaA]", re.IGNORECASE)
+DANGEROUS_HEADER_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+
+
+# ═══════════════════════════════════════════════════════════════════
+# CRLF Sanitizer for Header Values
+# ═══════════════════════════════════════════════════════════════════
+
+
+class CRLFSanitizer:
+    """Sanitizes user-controlled input before writing to HTTP response headers."""
+
+    @staticmethod
+    def contains_crlf(value: str) -> bool:
+        """Check if a value contains CRLF sequences (literal or URL-encoded)."""
+        if CRLF_PATTERN.search(value):
+            return True
+        if URL_ENCODED_CRLF.search(value):
+            return True
+        if re.search(r"%0[dd]|%0[aa]", value, re.IGNORECASE):
+            return True
+        return False
+
+    @staticmethod
+    def sanitize(value: str) -> str:
+        """Remove CRLF and control characters from input."""
+        result = value.replace("\r", "").replace("\n", "")
+        result = re.sub(r"%0d%0a", "", result, flags=re.IGNORECASE)
+        result = re.sub(r"%0a%0d", "", result, flags=re.IGNORECASE)
+        result = re.sub(r"%0d", "", result, flags=re.IGNORECASE)
+        result = re.sub(r"%0a", "", result, flags=re.IGNORECASE)
+        result = DANGEROUS_HEADER_CHARS.sub("", result)
+        return result
+
+    @staticmethod
+    def safe_encode(value: str) -> str:
+        """Encode value for safe inclusion in HTTP response headers."""
+        result = CRLFSanitizer.sanitize(value)
+        result = result.replace("\\", "\\\\")
+        result = result.replace('"', "&quot;")
+        return result
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Secure Access Log Header Handler
+# ═══════════════════════════════════════════════════════════════════
+
+
+class AccessLogHeader:
+    """Secure wrapper for access-log-style response headers."""
+
+    def __init__(self, enable_file_logging: bool = True):
+        self.enable_file_logging = enable_file_logging
+        self._file_logger = self._setup_logger() if enable_file_logging else None
+
+    def _setup_logger(self) -> logging.Logger:
+        logger = logging.getLogger("access_log")
+        logger.setLevel(logging.INFO)
+        if not logger.handlers:
+            handler = logging.StreamHandler()
+            formatter = logging.Formatter(
+                "%(asctime)s [%(levelname)s] %(message)s",
+                datefmt="%Y-%m-%dT%H:%M:%S%z",
+            )
+            handler.setFormatter(formatter)
+            logger.addHandler(handler)
+        return logger
+
+    def set_safe_header(self, name: str, value: str) -> Tuple[bool, Optional[str]]:
+        """Set a response header with full CRLF protection."""
+        if CRLFSanitizer.contains_crlf(value):
+            return False, "CRLF sequences detected and rejected"
+        safe_value = CRLFSanitizer.sanitize(value)
+        encoded_value = CRLFSanitizer.safe_encode(safe_value)
+        if self._file_logger:
+            self._file_logger.info(
+                "Header: %s | Value: %s | Sanitized: %s",
+                name, value[:100], safe_value[:100],
+            )
+        return True, encoded_value
+
+    def set_x_log_header(self, user_agent: str) -> Tuple[bool, Optional[str]]:
+        """Specifically fix the X-Log header pattern from issue #681."""
+        return self.set_safe_header("X-Log", user_agent)
+
+    def safe_user_agent_for_header(self, user_agent: str) -> str:
+        """Return a User-Agent value safe for response header reflection."""
+        return CRLFSanitizer.safe_encode(user_agent)
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Direct Fix: The Vulnerable Pattern
+# ═══════════════════════════════════════════════════════════════════
+
+
+def fix_access_log_header(user_agent: str) -> str:
+    """Drop-in replacement for the vulnerable res.setHeader('X-Log', userAgent).
+
+    Original:  res.setHeader("X-Log", userAgent)
+    Fixed:     res.setHeader("X-Log", fix_access_log_header(userAgent))
+    """
+    return CRLFSanitizer.safe_encode(user_agent)
+
+
+def is_safe_for_header(value: str) -> bool:
+    """Check if a value is safe to include in a response header."""
+    return not CRLFSanitizer.contains_crlf(value)
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+def test_crlf_detection():
+    assert CRLFSanitizer.contains_crlf("test\r\ninjection")
+    assert CRLFSanitizer.contains_crlf("test%0d%0ainjection")
+    assert CRLFSanitizer.contains_crlf("test%0D%0Ainjection")
+    assert CRLFSanitizer.contains_crlf("test%0dinjection")
+    assert CRLFSanitizer.contains_crlf("test%0ainjection")
+    assert not CRLFSanitizer.contains_crlf("Mozilla/5.0 (Macintosh)")
+    assert not CRLFSanitizer.contains_crlf("curl/7.68.0")
+    print("PASS: CRLF detection")
+
+
+def test_crlf_sanitization():
+    sanitized = CRLFSanitizer.sanitize("test\r\ninjection")
+    assert "\r" not in sanitized
+    assert "\n" not in sanitized
+    assert sanitized == "testinjection"
+    sanitized = CRLFSanitizer.sanitize("test%0d%0ainjection")
+    assert "%0d" not in sanitized.lower()
+    ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"
+    assert CRLFSanitizer.sanitize(ua) == ua
+    print("PASS: CRLF sanitization")
+
+
+def test_safe_encoding():
+    ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"
+    assert CRLFSanitizer.safe_encode(ua) == ua
+    encoded = CRLFSanitizer.safe_encode("Mozilla\r\nX-Evil: true")
+    assert "\r" not in encoded
+    assert "\n" not in encoded
+    print("PASS: Safe encoding")
+
+
+def test_drop_in_replacement():
+    result = fix_access_log_header("Mozilla/5.0 (Windows NT 10.0)")
+    assert "Mozilla" in result
+    assert "\r" not in result
+    result = fix_access_log_header("EvilBot\r\nX-Hacked: true\r\n")
+    assert "\r" not in result
+    assert "X-Hacked" not in result
+    print("PASS: Drop-in replacement")
+
+
+def test_access_log_header_class():
+    logger = AccessLogHeader(enable_file_logging=False)
+    success, value = logger.set_x_log_header("Mozilla/5.0")
+    assert success
+    success, value = logger.set_x_log_header("EvilBot\r\nSet-Cookie: malicious=true")
+    assert not success
+    print("PASS: AccessLogHeader class")
+
+
+def test_real_world_attack_vectors():
+    vectors = [
+        "Mozilla/5.0\r\nX-Hacked: true\r\n",
+        "curl/7.68.0%0d%0aX-Hacked:%20true",
+        "Python/3.9%0d%0aSet-Cookie:%20session=malicious",
+        "Bot\r\nLocation: https://evil.com\r\n",
+        "Mozilla/5.0\r\nContent-Length: 0\r\n\r\n<html>injected</html>",
+        "Normal/1.0 (compatible)",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+    ]
+    for v in vectors:
+        result = fix_access_log_header(v)
+        assert "\r" not in result
+        assert "\n" not in result
+    print("PASS: All attack vectors handled")
+
+
+def test_edge_cases():
+    assert CRLFSanitizer.safe_encode("") == ""
+    assert CRLFSanitizer.safe_encode("\r\n") == ""
+    result = CRLFSanitizer.safe_encode("a\r\nb\r\nc")
+    assert result == "abc"
+    result = CRLFSanitizer.safe_encode("Mozilla/5.0 (中文/日本語)")
+    assert "中文" in result
+    assert "日本語" in result
+    result = CRLFSanitizer.safe_encode("test\x09value")
+    assert "\x09" not in result
+    result = CRLFSanitizer.safe_encode("test\x00value")
+    assert "\x00" not in result
+    print("PASS: Edge cases")
+
+
+def test_is_safe_for_header():
+    assert not is_safe_for_header("test\r\ninjection")
+    assert not is_safe_for_header("test%0d%0ainjection")
+    assert is_safe_for_header("Safe User-Agent String")
+    assert is_safe_for_header("Mozilla/5.0 (compatible; Googlebot/2.1)")
+    print("PASS: is_safe_for_header")
+
+
+if __name__ == "__main__":
+    test_crlf_detection()
+    test_crlf_sanitization()
+    test_safe_encoding()
+    test_drop_in_replacement()
+    test_access_log_header_class()
+    test_real_world_attack_vectors()
+    test_edge_cases()
+    test_is_safe_for_header()
+    print("\n✅ ALL 8 TESTS PASSED — Access Log CRLF Injection Fix Complete!")

--- a/FIXES/fix_clickjacking_crypto.py
+++ b/FIXES/fix_clickjacking_crypto.py
@@ -1,0 +1,295 @@
+"""
+fix_clickjacking_crypto.py — Clickjacking → Crypto Withdrawal Protection
+
+Issue #727 — Asset withdrawal page lacks X-Frame-Options / CSP frame-ancestors,
+allowing attackers to overlay transparent iframes and trick users into clicking
+confirm-withdrawal buttons.
+
+FIX:
+1. Add X-Frame-Options: DENY to all responses
+2. Add Content-Security-Policy: frame-ancestors 'none'
+3. Add double-confirmation for critical operations (withdraw, transfer, etc.)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Configuration
+# ═══════════════════════════════════════════════════════════════════
+
+SECURE_HEADERS = {
+    "X-Frame-Options": "DENY",
+    "Content-Security-Policy": "frame-ancestors 'none'",
+    "X-Content-Type-Options": "nosniff",
+}
+
+CRITICAL_ACTIONS = {"withdraw", "transfer", "send", "approve", "delegate"}
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 1. Secure Headers Middleware
+# ═══════════════════════════════════════════════════════════════════
+
+
+class SecureHeadersMiddleware:
+    """WSGI middleware that adds anti-clickjacking headers to all responses."""
+
+    def __init__(self, app, extra_headers: Optional[Dict[str, str]] = None):
+        self.app = app
+        self.headers = {**SECURE_HEADERS, **(extra_headers or {})}
+
+    def __call__(self, environ, start_response):
+        def secure_start_response(status, headers, exc_info=None):
+            for name, value in self.headers.items():
+                headers.append((name, value))
+            return start_response(status, headers, exc_info)
+
+        return self.app(environ, secure_start_response)
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 2. Response Header Fix
+# ═══════════════════════════════════════════════════════════════════
+
+
+def add_anti_clickjacking_headers(
+    headers: List[Tuple[str, str]]
+) -> List[Tuple[str, str]]:
+    """Add anti-clickjacking headers to a response header list."""
+    header_dict = dict(headers)
+    header_dict["X-Frame-Options"] = "DENY"
+    header_dict["Content-Security-Policy"] = "frame-ancestors 'none'"
+    return list(header_dict.items())
+
+
+def set_anti_clickjacking_headers(response: Any) -> Any:
+    """Set anti-clickjacking headers on a response object."""
+    if hasattr(response, "headers"):
+        if hasattr(response.headers, "__setitem__"):
+            response.headers["X-Frame-Options"] = "DENY"
+            response.headers["Content-Security-Policy"] = "frame-ancestors 'none'"
+            response.headers["X-Content-Type-Options"] = "nosniff"
+    return response
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 3. Double Confirmation for Critical Operations
+# ═══════════════════════════════════════════════════════════════════
+
+
+class DoubleConfirmation:
+    """Provides double-confirmation mechanism for critical operations."""
+
+    def __init__(self, secret_key: Optional[str] = None):
+        self.secret_key = secret_key or os.urandom(32).hex()
+        self._pending: Dict[str, dict] = {}
+
+    def _generate_token(self, action: str, user_id: str, amount: float) -> str:
+        """Generate a time-limited confirmation token."""
+        payload = {
+            "action": action,
+            "user_id": user_id,
+            "amount": amount,
+            "timestamp": int(time.time()),
+            "nonce": os.urandom(8).hex(),
+        }
+        # Store the full payload with the original nonce for verification
+        payload_bytes = json.dumps(payload, sort_keys=True).encode()
+        signature = hmac.new(
+            self.secret_key.encode(), payload_bytes, hashlib.sha256
+        ).hexdigest()[:16]
+        token = f"{signature}:{payload['timestamp']}:{payload['nonce']}"
+        self._pending[token] = payload
+        return token
+
+    def _verify_signature(self, token: str) -> bool:
+        """Verify the token signature against stored payload."""
+        if token not in self._pending:
+            return False
+        payload = self._pending[token]
+        payload_bytes = json.dumps(payload, sort_keys=True).encode()
+        expected_sig = hmac.new(
+            self.secret_key.encode(), payload_bytes, hashlib.sha256
+        ).hexdigest()[:16]
+        actual_sig = token.split(":")[0]
+        return hmac.compare_digest(expected_sig, actual_sig)
+
+    def request_confirmation(
+        self, action: str, user_id: str, amount: float
+    ) -> Dict[str, Any]:
+        """Request double confirmation for a critical operation."""
+        token = self._generate_token(action, user_id, amount)
+        return {
+            "type": "double_confirmation",
+            "message": (
+                f"⚠️ CRITICAL ACTION: {action.upper()}\n"
+                f"Amount: ${amount:.2f}\n"
+                f"Please confirm this operation by clicking the confirm button."
+            ),
+            "confirm_token": token,
+            "expires_in": 300,
+        }
+
+    def confirm(self, token: str) -> Tuple[bool, str]:
+        """Confirm a pending critical operation."""
+        if token not in self._pending:
+            return False, "Invalid or expired confirmation token"
+
+        payload = self._pending[token]
+        elapsed = int(time.time()) - payload["timestamp"]
+
+        if elapsed > 300:
+            del self._pending[token]
+            return False, "Confirmation token expired (5 minute limit)"
+
+        if not self._verify_signature(token):
+            del self._pending[token]
+            return False, "Token signature mismatch"
+
+        del self._pending[token]
+        return True, f"{payload['action']} confirmed for user {payload['user_id']}"
+
+    def cleanup_expired(self):
+        """Remove expired tokens."""
+        now = int(time.time())
+        expired = [
+            t for t, p in self._pending.items()
+            if now - p["timestamp"] > 300
+        ]
+        for t in expired:
+            del self._pending[t]
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 4. Direct Fix
+# ═══════════════════════════════════════════════════════════════════
+
+
+def fix_withdrawal_page_security(response_headers: Dict[str, str]) -> Dict[str, str]:
+    """Drop-in fix for withdrawal page missing anti-clickjacking headers."""
+    response_headers["X-Frame-Options"] = "DENY"
+    response_headers["Content-Security-Policy"] = "frame-ancestors 'none'"
+    response_headers["X-Content-Type-Options"] = "nosniff"
+    return response_headers
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+def test_secure_headers_middleware():
+    def dummy_app(environ, start_response):
+        start_response("200 OK", [("Content-Type", "text/html")])
+        return [b"<html><body>test</body></html>"]
+
+    middleware = SecureHeadersMiddleware(dummy_app)
+    headers_captured = []
+
+    def capture_start_response(status, headers, exc_info=None):
+        headers_captured.extend(headers)
+        return lambda x: None
+
+    list(middleware({}, capture_start_response))
+    hd = dict(headers_captured)
+    assert hd.get("X-Frame-Options") == "DENY"
+    assert hd.get("Content-Security-Policy") == "frame-ancestors 'none'"
+    assert hd.get("X-Content-Type-Options") == "nosniff"
+    print("PASS: SecureHeadersMiddleware")
+
+
+def test_add_anti_clickjacking_headers():
+    original = [("Content-Type", "text/html")]
+    updated = add_anti_clickjacking_headers(original)
+    ud = dict(updated)
+    assert ud["X-Frame-Options"] == "DENY"
+    assert ud["Content-Security-Policy"] == "frame-ancestors 'none'"
+    assert ud["Content-Type"] == "text/html"
+    print("PASS: add_anti_clickjacking_headers")
+
+
+def test_double_confirmation():
+    dc = DoubleConfirmation(secret_key="test-secret-key")
+    challenge = dc.request_confirmation("withdraw", "user123", 100.0)
+    assert challenge["type"] == "double_confirmation"
+    assert "withdraw" in challenge["message"].lower()
+    assert challenge["expires_in"] == 300
+    token = challenge["confirm_token"]
+
+    success, msg = dc.confirm(token)
+    assert success, f"Expected success, got: {msg}"
+    assert "confirmed" in msg.lower()
+
+    # Cannot reuse
+    success, msg = dc.confirm(token)
+    assert not success
+    print("PASS: DoubleConfirmation")
+
+
+def test_fix_withdrawal_page_security():
+    original = {"Content-Type": "text/html"}
+    fixed = fix_withdrawal_page_security(original)
+    assert fixed["X-Frame-Options"] == "DENY"
+    assert fixed["Content-Security-Policy"] == "frame-ancestors 'none'"
+    assert fixed["Content-Type"] == "text/html"
+    print("PASS: fix_withdrawal_page_security")
+
+
+def test_set_anti_clickjacking_headers():
+    class MockResponse:
+        def __init__(self):
+            self.headers = {}
+
+    resp = MockResponse()
+    set_anti_clickjacking_headers(resp)
+    assert resp.headers["X-Frame-Options"] == "DENY"
+    assert resp.headers["Content-Security-Policy"] == "frame-ancestors 'none'"
+    print("PASS: set_anti_clickjacking_headers")
+
+
+def test_critical_actions():
+    for a in ("withdraw", "transfer", "send", "approve", "delegate"):
+        assert a in CRITICAL_ACTIONS
+    print("PASS: Critical actions")
+
+
+def test_expired_token():
+    dc = DoubleConfirmation(secret_key="test-key")
+    challenge = dc.request_confirmation("withdraw", "user1", 50.0)
+    token = challenge["confirm_token"]
+    # Force expiry
+    dc._pending[token]["timestamp"] = int(time.time()) - 600
+    success, msg = dc.confirm(token)
+    assert not success
+    assert "expired" in msg.lower()
+    print("PASS: Expired token rejection")
+
+
+def test_cleanup_expired():
+    dc = DoubleConfirmation(secret_key="test-key")
+    challenge = dc.request_confirmation("withdraw", "user1", 50.0)
+    token = challenge["confirm_token"]
+    dc._pending[token]["timestamp"] = int(time.time()) - 600
+    dc.cleanup_expired()
+    assert token not in dc._pending
+    print("PASS: Cleanup expired")
+
+
+if __name__ == "__main__":
+    test_secure_headers_middleware()
+    test_add_anti_clickjacking_headers()
+    test_double_confirmation()
+    test_fix_withdrawal_page_security()
+    test_set_anti_clickjacking_headers()
+    test_critical_actions()
+    test_expired_token()
+    test_cleanup_expired()
+    print("\n✅ ALL 8 TESTS PASSED — Clickjacking Protection Fix Complete!")


### PR DESCRIPTION
## 修复: Clickjacking → 加密货币提现保护

**关联 Issue:** #727

### 漏洞描述
资产提现页面缺少 X-Frame-Options / CSP frame-ancestors，攻击者可构建透明 iframe 诱导用户点击确认提现按钮。

### 修复方案
在 `fixes/fix_clickjacking_crypto.py` 中提供:

1. **SecureHeadersMiddleware** — WSGI中间件，自动添加 X-Frame-Options: DENY + CSP frame-ancestors 'none'
2. **add_anti_clickjacking_headers()** — 响应头列表添加函数
3. **DoubleConfirmation** — 关键操作双确认机制（HMAC签名token，5分钟有效期）
4. **fix_withdrawal_page_security()** — 直接替换函数

### 验收标准
- [x] 设置 X-Frame-Options: DENY
- [x] 设置 Content-Security-Policy: frame-ancestors 'none'
- [x] 关键操作需要二次确认

### 测试
8 个测试用例全部通过