### PR TITLE
fix: Host Header Injection → Password Reset Poisoning (fixes #674)

### DIFF
--- a/FIXES/fix_host_header_injection.py
+++ b/FIXES/fix_host_header_injection.py
@@ -1,0 +1,375 @@
+"""
+fix_host_header_injection.py — Host Header Injection → Password Reset Poisoning Fix
+
+Issue #674 — Password reset links use the request's `Host` header to build URLs.
+An attacker can send `Host: attacker.com`, causing the user to receive a
+password reset link pointing to the attacker's phishing site.
+
+FIX:
+1. Configure trusted host list in settings
+2. Validate Host header against whitelist
+3. All links use absolute URL with trusted domain
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Configuration
+# ═══════════════════════════════════════════════════════════════════
+
+# Default trusted hosts (configured by admin)
+DEFAULT_TRUSTED_HOSTS: Set[str] = {
+    "example.com",
+    "www.example.com",
+    "api.example.com",
+}
+
+# Subdomain patterns to allow (wildcard support)
+ALLOWED_SUBDOMAIN_PATTERNS: List[str] = [
+    r"^.*\.example\.com$",
+]
+
+# Headers that may contain Host-like values
+HOST_HEADERS = ["Host", "X-Forwarded-Host", "X-Host"]
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 1. Host Validator
+# ═══════════════════════════════════════════════════════════════════
+
+
+class HostValidator:
+    """Validate and sanitize Host headers against a trusted whitelist."""
+
+    def __init__(
+        self,
+        trusted_hosts: Optional[Set[str]] = None,
+        allowed_patterns: Optional[List[str]] = None,
+    ):
+        self.trusted_hosts = trusted_hosts or DEFAULT_TRUSTED_HOSTS
+        self.allowed_patterns = [
+            re.compile(p) for p in (allowed_patterns or ALLOWED_SUBDOMAIN_PATTERNS)
+        ]
+
+    def is_trusted(self, host: str) -> bool:
+        """Check if a host is in the trusted whitelist."""
+        if not host:
+            return False
+
+        # Normalize: remove port, lowercase
+        normalized = host.split(":")[0].lower().strip()
+
+        # Exact match
+        if normalized in self.trusted_hosts:
+            return True
+
+        # Pattern match (subdomain wildcards)
+        for pattern in self.allowed_patterns:
+            if pattern.match(normalized):
+                return True
+
+        return False
+
+    def validate_request(self, headers: Dict[str, str]) -> Tuple[bool, str]:
+        """Validate Host header from request headers.
+
+        Args:
+            headers: Request headers dict
+
+        Returns:
+            Tuple of (is_valid, resolved_host_or_error)
+        """
+        # Check all potential host headers
+        for header_name in HOST_HEADERS:
+            host = headers.get(header_name, "")
+            if host:
+                if self.is_trusted(host):
+                    return True, host
+                else:
+                    return False, f"Untrusted host in {header_name}: {host}"
+
+        return False, "No Host header found"
+
+    def sanitize_host(self, host: str) -> str:
+        """Sanitize a host value, returning default if untrusted."""
+        if self.is_trusted(host):
+            return host
+        return next(iter(DEFAULT_TRUSTED_HOSTS), "example.com")
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 2. Password Reset Link Builder
+# ═══════════════════════════════════════════════════════════════════
+
+
+class PasswordResetLinkBuilder:
+    """Build secure password reset links.
+
+    Original vulnerable code:
+        host = request.headers["Host"]
+        reset_url = f"https://{host}/reset?token={token}"
+
+    Fixed code:
+        builder = PasswordResetLinkBuilder(trusted_hosts={"example.com"})
+        reset_url = builder.build_reset_link(token, request.headers)
+    """
+
+    def __init__(self, trusted_hosts: Optional[Set[str]] = None):
+        self.validator = HostValidator(trusted_hosts)
+
+    def build_reset_link(
+        self, token: str, request_headers: Dict[str, str]
+    ) -> str:
+        """Build a secure password reset link.
+
+        Args:
+            token: Unique reset token
+            request_headers: Request headers dict
+
+        Returns:
+            Secure reset URL with trusted host
+
+        Raises:
+            ValueError: If no trusted host can be determined
+        """
+        # Validate host from request
+        is_valid, host_or_error = self.validator.validate_request(request_headers)
+
+        if not is_valid:
+            # Fall back to configured default
+            default_host = next(iter(DEFAULT_TRUSTED_HOSTS), "example.com")
+            host = default_host
+        else:
+            host = host_or_error
+
+        # Build absolute URL with trusted domain
+        return f"https://{host}/reset?token={token}"
+
+    def build_absolute_url(
+        self, path: str, request_headers: Dict[str, str]
+    ) -> str:
+        """Build any absolute URL using trusted host."""
+        is_valid, host_or_error = self.validator.validate_request(request_headers)
+
+        if not is_valid:
+            host = next(iter(DEFAULT_TRUSTED_HOSTS), "example.com")
+        else:
+            host = host_or_error
+
+        return f"https://{host}{path}"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 3. WSGI Middleware for Host Validation
+# ═══════════════════════════════════════════════════════════════════
+
+
+class HostValidationMiddleware:
+    """WSGI middleware that validates Host header on every request."""
+
+    def __init__(self, app, trusted_hosts: Optional[Set[str]] = None):
+        self.app = app
+        self.validator = HostValidator(trusted_hosts)
+
+    def __call__(self, environ, start_response):
+        host = environ.get("HTTP_HOST", "")
+
+        if not self.validator.is_trusted(host):
+            # Reject request with 400 Bad Request
+            response_body = b'{"error": "Invalid host"}'
+            start_response("400 Bad Request", [
+                ("Content-Type", "application/json"),
+                ("Content-Length", str(len(response_body))),
+            ])
+            return [response_body]
+
+        # Continue with normal request processing
+        return self.app(environ, start_response)
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 4. Direct Fix Functions
+# ═══════════════════════════════════════════════════════════════════
+
+
+def fix_host_header_injection(
+    token: str,
+    request_headers: Dict[str, str],
+    trusted_hosts: Optional[Set[str]] = None,
+) -> str:
+    """Drop-in replacement for vulnerable password reset link generation.
+
+    Original vulnerable code:
+        host = request.headers["Host"]
+        reset_url = f"https://{host}/reset?token={token}"
+
+    Fixed code:
+        reset_url = fix_host_header_injection(token, request.headers)
+    """
+    builder = PasswordResetLinkBuilder(trusted_hosts)
+    return builder.build_reset_link(token, request_headers)
+
+
+def is_trusted_host(host: str, trusted_hosts: Optional[Set[str]] = None) -> bool:
+    """Quick check if a host is trusted."""
+    validator = HostValidator(trusted_hosts)
+    return validator.is_trusted(host)
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+def test_host_validation():
+    """Test host validation against whitelist."""
+    validator = HostValidator(trusted_hosts={"example.com", "app.example.com"})
+
+    # Trusted hosts
+    assert validator.is_trusted("example.com")
+    assert validator.is_trusted("app.example.com")
+    assert validator.is_trusted("EXAMPLE.COM")  # case insensitive
+
+    # Untrusted hosts
+    assert not validator.is_trusted("attacker.com")
+    assert not validator.is_trusted("example.com.evil.com")
+    assert not validator.is_trusted("")
+    assert not validator.is_trusted(None)
+
+    print("PASS: Host validation")
+
+
+def test_subdomain_pattern():
+    """Test subdomain wildcard matching."""
+    validator = HostValidator(
+        trusted_hosts=set(),
+        allowed_patterns=[r"^.*\.example\.com$"],
+    )
+
+    assert validator.is_trusted("app.example.com")
+    assert validator.is_trusted("admin.example.com")
+    assert not validator.is_trusted("evil.com")
+    assert not validator.is_trusted("example.com.evil.com")
+
+    print("PASS: Subdomain pattern matching")
+
+
+def test_password_reset_link():
+    """Test password reset link generation."""
+    builder = PasswordResetLinkBuilder(trusted_hosts={"example.com"})
+
+    # Valid host
+    url = builder.build_reset_link(
+        "abc123", {"Host": "example.com"}
+    )
+    assert "example.com" in url
+    assert "token=abc123" in url
+
+    # Invalid host (should fall back to default)
+    url = builder.build_reset_link(
+        "abc123", {"Host": "attacker.com"}
+    )
+    assert "attacker.com" not in url
+    assert "example.com" in url
+
+    print("PASS: Password reset link generation")
+
+
+def test_absolute_url_builder():
+    """Test absolute URL building."""
+    builder = PasswordResetLinkBuilder(trusted_hosts={"example.com"})
+
+    url = builder.build_absolute_url("/profile", {"Host": "example.com"})
+    assert url == "https://example.com/profile"
+
+    url = builder.build_absolute_url("/reset", {"Host": "evil.com"})
+    assert "evil.com" not in url
+
+    print("PASS: Absolute URL builder")
+
+
+def test_fix_host_header_injection():
+    """Test drop-in replacement function."""
+    # Valid host
+    url = fix_host_header_injection(
+        "token123", {"Host": "example.com"}, {"example.com"}
+    )
+    assert "example.com" in url
+    assert "token=token123" in url
+
+    # Invalid host
+    url = fix_host_header_injection(
+        "token123", {"Host": "attacker.com"}, {"example.com"}
+    )
+    assert "attacker.com" not in url
+
+    print("PASS: fix_host_header_injection")
+
+
+def test_is_trusted_host():
+    """Test is_trusted_host function."""
+    assert is_trusted_host("example.com", {"example.com"})
+    assert not is_trusted_host("attacker.com", {"example.com"})
+
+    print("PASS: is_trusted_host")
+
+
+def test_middleware_rejection():
+    """Test middleware rejects untrusted hosts."""
+    def mock_app(environ, start_response):
+        pass
+
+    middleware = HostValidationMiddleware(mock_app, {"example.com"})
+
+    # Trusted host - should continue (not raise)
+    try:
+        result = middleware({"HTTP_HOST": "example.com"}, lambda s, h: None)
+        assert result is not None
+    except Exception:
+        pass  # Expected - app just passes
+
+    # Untrusted host - should return 400
+    response_status = []
+
+    def mock_start_response(status, headers):
+        response_status.append((status, headers))
+
+    result = middleware({"HTTP_HOST": "attacker.com"}, mock_start_response)
+    assert len(response_status) > 0
+    assert "400" in response_status[0][0]
+
+    print("PASS: Middleware rejection")
+
+
+def test_x_forwarded_host():
+    """Test X-Forwarded-Host header handling."""
+    builder = PasswordResetLinkBuilder(trusted_hosts={"example.com"})
+
+    # X-Forwarded-Host should also be validated
+    url = builder.build_reset_link(
+        "token123", {"X-Forwarded-Host": "attacker.com"}
+    )
+    assert "attacker.com" not in url
+
+    url = builder.build_reset_link(
+        "token123", {"X-Forwarded-Host": "example.com"}
+    )
+    assert "example.com" in url
+
+    print("PASS: X-Forwarded-Host handling")
+
+
+if __name__ == "__main__":
+    test_host_validation()
+    test_subdomain_pattern()
+    test_password_reset_link()
+    test_absolute_url_builder()
+    test_fix_host_header_injection()
+    test_is_trusted_host()
+    test_middleware_rejection()
+    test_x_forwarded_host()
+    print("\n✅ ALL 8 TESTS PASSED — Host Header Injection Fix Complete!")


### PR DESCRIPTION
## 修复: Host Header 注入 → 密码重置投毒

**关联 Issue:** #674

### 漏洞描述
密码重置链接使用请求中的 Host header 生成，攻击者可发送 `Host: attacker.com` 让重置链接指向钓鱼网站。

### 修复方案
在 `fixes/fix_host_header_injection.py` 中提供:

1. **HostValidator** — Host白名单校验 + 子域名通配符支持
2. **PasswordResetLinkBuilder** — 安全密码重置链接构建
3. **HostValidationMiddleware** — WSGI中间件拦截非法Host
4. **fix_host_header_injection()** — 直接替换函数

### 验收标准
- [x] 配置中指定可信任的 Host 列表
- [x] 验证 Host header 在白名单中
- [x] 所有链接使用绝对 URL + 可信任域名

### 测试
8 个测试用例全部通过