### PR TITLE
fix: HTTP Parameter Pollution — duplicate param rejection (fixes #40)

### DIFF
--- a/FIXES/fix_http_param_pollution_40.py
+++ b/FIXES/fix_http_param_pollution_40.py
@@ -1,0 +1,67 @@
+"""
+Fix for Issue #40 — HTTP Parameter Pollution
+Agent: lushan888 (via dev-nana27)
+Bounty: $10 USD
+
+Fix: Validate and deduplicate HTTP parameters by keeping only the first value,
+and reject requests with duplicate parameters to prevent HPP attacks.
+"""
+
+from flask import request, jsonify
+from urllib.parse import parse_qs
+from typing import Dict, List, Tuple, Optional
+
+
+def sanitize_query_params(params: Dict[str, List[str]]) -> Dict[str, str]:
+    """Deduplicate HTTP parameters — keep only the first value.
+
+    Flask's default request.args allows duplicate keys, where the last value
+    wins. An attacker can inject security parameters like ?admin=true&admin=false
+    to bypass checks.
+
+    This function returns the FIRST value for each parameter, preventing
+    parameter pollution attacks.
+    """
+    return {k: v[0] for k, v in params.items() if v}
+
+
+def get_deduplicated_params() -> Dict[str, str]:
+    """Parse and deduplicate HTTP query parameters.
+
+    Returns a dict with only the first value for each parameter name.
+    """
+    raw = request.query_string.decode("utf-8") if request.query_string else ""
+    parsed = parse_qs(raw, keep_blank_values=True)
+    return sanitize_query_params(parsed)
+
+
+def validate_no_duplicate_params() -> Tuple[bool, Optional[Tuple]]:
+    """Reject requests with duplicate parameters.
+
+    Returns (is_valid, error_response_or_None).
+    If is_valid is False, error_response is a Flask tuple (body, status_code).
+    """
+    raw = request.query_string.decode("utf-8") if request.query_string else ""
+    if not raw:
+        return True, None
+
+    seen = set()
+    for pair in raw.split("&"):
+        if not pair:
+            continue
+        key = pair.split("=")[0]
+        if key in seen:
+            return (
+                False,
+                (
+                    jsonify(
+                        {
+                            "error": "Duplicate parameter detected",
+                            "message": "HTTP Parameter Pollution attack detected",
+                        }
+                    ),
+                    400,
+                ),
+            )
+        seen.add(key)
+    return True, None

--- a/src/app.py
+++ b/src/app.py
@@ -1,7 +1,8 @@
-from flask import Flask, request, render_template_string, make_response, session
+from flask import Flask, request, render_template_string, make_response, session, jsonify
 import sqlite3
 import secrets
 import html
+from urllib.parse import parse_qs
 
 app = Flask(__name__)
 app.secret_key = secrets.token_hex(32)
@@ -51,6 +52,32 @@ def login():
             return resp
     
     return "Invalid credentials", 401
+@app.before_request
+def sanitize_query_params():
+    """Validate and deduplicate HTTP query parameters on every request.
+    
+    Prevents HTTP Parameter Pollution (HPP) attacks where an attacker sends
+    duplicate parameters (?admin=true&admin=false) to bypass security checks.
+    """
+    if not request.query_string:
+        return
+    
+    raw = request.query_string.decode('utf-8')
+    
+    # Reject requests with duplicate parameters outright
+    seen = set()
+    for pair in raw.split('&'):
+        if not pair:
+            continue
+        key = pair.split('=')[0]
+        if key in seen:
+            return jsonify({
+                'error': 'Duplicate parameter detected',
+                'message': 'HTTP Parameter Pollution attack detected'
+            }), 400
+        seen.add(key)
+
+
 @app.route('/search')
 def search():
     query = request.args.get('q', '')


### PR DESCRIPTION
## Fix for Issue #40 — HTTP Parameter Pollution

**Bounty**: $10

### What
Implements HTTP Parameter Pollution (HPP) protection via a Flask `before_request` middleware:

1. **Duplicate parameter rejection** — Requests with duplicate query parameters (e.g., `?admin=true&admin=false`) are rejected with a 400 response
2. **Middleware hook** — `sanitize_query_params()` runs on every request, preventing HPP before any route handler processes params
3. **Utility functions** — `FIXES/fix_http_param_pollution_40.py` provides `get_deduplicated_params()` and `validate_no_duplicate_params()` for reusability

### Acceptance Criteria
- [x] Reject requests with duplicate HTTP parameters
- [x] Prevent parameter pollution attacks on all routes
- [x] Return proper 400 error with descriptive message

### Files
- `src/app.py` — Added `sanitize_query_params()` before_request middleware
- `FIXES/fix_http_param_pollution_40.py` — Utility functions for parameter deduplication

### Wallet for Bounty Payment
- **ETH/EVM (Ethereum, Polygon, Base, Optimism, Arbitrum):** `0x415b24ab21388dbfb9c4da97cb1ab2b53ff21e29`
- **SOL (Solana):** `J6pwNJNbjYx7UHAvZK369kYRJHim8JVbeFEHRSqtFMjv`