### PR TITLE
fix(security): add CSP frame-ancestors and security headers (#1176)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -10,6 +10,9 @@ app.secret_key = secrets.token_hex(32)
 @app.after_request
 def add_security_headers(response):
     response.headers['X-Frame-Options'] = 'DENY'
+    response.headers['Content-Security-Policy'] = "frame-ancestors 'none'"
+    response.headers['X-Content-Type-Options'] = 'nosniff'
+    response.headers['X-XSS-Protection'] = '1; mode=block'
     return response
 
 # Simulated user database


### PR DESCRIPTION
## Fix for Issue #1176 — Clickjacking via X-Frame-Options Missing

### Vulnerability
Asset withdrawal page was missing Content-Security-Policy header, allowing attackers to embed the page in an iframe for clickjacking attacks.

### Changes
- Added Content-Security-Policy: frame-ancestors 'none' to all responses
- Added X-Content-Type-Options: nosniff header
- Added X-XSS-Protection: 1; mode=block header
- X-Frame-Options: DENY already present, now complete with CSP

### Acceptance Criteria
- [x] Set X-Frame-Options: DENY
- [x] Set Content-Security-Policy: frame-ancestors 'none'
- [x] Added additional security headers (X-Content-Type-Options, X-XSS-Protection)