### PR TITLE
fix: add CSP frame-ancestors 'none' for Clickjacking protection (#1176)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -10,6 +10,7 @@ app.secret_key = secrets.token_hex(32)
 @app.after_request
 def add_security_headers(response):
     response.headers['X-Frame-Options'] = 'DENY'
+    response.headers['Content-Security-Policy'] = "frame-ancestors 'none'"
     return response
 
 # Simulated user database


### PR DESCRIPTION
Fixes #1176 - Clickjacking on withdrawal page

- Adds `Content-Security-Policy: frame-ancestors 'none'` header
- Combined with existing `X-Frame-Options: DENY` for defense-in-depth
- Meets bounty acceptance criteria

Wallet for payout: `0xACCE0F0D9065F57ae1a1aaE69eE4e2302c3227bb`