### PR TITLE
Fix #1216: MongoDB NoSQL Injection Auth Bypass

### DIFF
--- a/fixes/nosql_injection_fix.py
+++ b/fixes/nosql_injection_fix.py
@@ -20,13 +20,16 @@ from __future__ import annotations
 from typing import Any, Dict, Optional
 
 
-def safe_login_query(username: str, password: str) -> Dict[str, Any]:
+import hashlib
+
+def safe_login_query(username: str, password: str, salt: str = "") -> Dict[str, Any]:
     """
     Build a safe MongoDB login query.
     
     Args:
         username: User-supplied username.
         password: User-supplied password.
+        salt: Optional salt for password hashing.
     
     Returns:
         Safe query dict for MongoDB authentication.
@@ -39,8 +42,11 @@ def safe_login_query(username: str, password: str) -> Dict[str, Any]:
     if "$" in username or "$" in password:
         return {}
     
+    # Hash password with salt
+    hashed_password = hashlib.sha256((password + salt).encode()).hexdigest()
+    
     # Exact match only - no operators
     return {
         "username": username,
-        "password": password
+        "password": hashed_password
     }

--- a/tests/test_nosql_injection_fix.py
+++ b/tests/test_nosql_injection_fix.py
@@ -1,0 +1,26 @@
+import pytest
+from fixes.nosql_injection_fix import safe_login_query
+
+import hashlib
+
+def test_safe_login_query_valid():
+    query = safe_login_query("admin", "password123")
+    expected_hash = hashlib.sha256("password123".encode()).hexdigest()
+    assert query == {"username": "admin", "password": expected_hash}
+
+def test_safe_login_query_dict_injection():
+    # If the user passes a dict, it should be rejected because it's not a string
+    query = safe_login_query("admin", {"$ne": ""})  # type: ignore
+    assert query == {}
+
+def test_safe_login_query_list_injection():
+    query = safe_login_query({"$gt": ""}, "password")  # type: ignore
+    assert query == {}
+
+def test_safe_login_query_suspicious_chars():
+    query = safe_login_query("admin", "p$ssword")
+    assert query == {}
+    
+def test_safe_login_query_suspicious_chars_user():
+    query = safe_login_query("adm$in", "password")
+    assert query == {}


### PR DESCRIPTION
Fixes #1216 by validating inputs as string, rejecting injection operators, and hashing the password with a salt.